### PR TITLE
Blc on changed files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ install:
 - node_modules/.bin/gitbook serve --no-live --no-watch &
 # wait for gitboook serve spinup
 - sleep 20
-#check all links using blc, skip example http://localhost:8000 link from the javascript chapter.
-script: node_modules/.bin/blc --exclude http://localhost:8000 --recursive http://localhost:4000
+# check all links using blc
+script: bash blc-on-changed-files.sh

--- a/blc-on-changed-files.sh
+++ b/blc-on-changed-files.sh
@@ -32,14 +32,25 @@ EXIT_CODE=0
 # read an individual line from the changed-files.txt file
 while read line;
 do 
+    echo "travis_fold:start:blc"
     # Use awk to find and replace the filename extension .md with .html,
     # concatenate with the gitbook server location, feed that to
     # broken-link-checker via its 'input' argument
-    blc --input `echo $GITBOOK_LOCATION/$line | awk '{ gsub(".md$",".html",$1); print $1 }'`;
+    blc --input `echo $GITBOOK_LOCATION/$line | awk '{ gsub(".md$",".html",$1); print $1 }'` 2>/dev/null | tee stdout.txt;
     # Take note of the success or failure of the blc command.
     if [ $? -ne 0 ]; then
         EXIT_CODE=1
     fi
+
+    N_BROKEN=$(cat stdout.txt | grep --regexp="^.\{2\}[BROKEN]" | wc -l)
+    if [ $N_BROKEN -eq 0 ]; then
+        echo "No broken links found."
+        echo "travis_fold:end:blc"
+    else
+        echo "travis_fold:end:blc"
+        cat stdout.txt | grep --invert-match --regexp="^.\{2\}[^BR]\{2\}OK[^EN]\{2\}"
+    fi
+
 done < changed-files.txt
 
 # If any failures have occurred during the above while loop, exit with a failure

--- a/blc-on-changed-files.sh
+++ b/blc-on-changed-files.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 
 BASE_BRANCH='master'
-CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 GITBOOK_LOCATION='http://localhost:4000'
 
-echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
-echo "TRAVIS_PULL_REQUEST_SHA=$TRAVIS_PULL_REQUEST_SHA"
-echo "TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH"
-
+git fetch origin refs/heads/$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH
+BASE_BRANCH_SHA=`git rev-parse origin/$BASE_BRANCH`
 # If the git diff result below is something like:
 # readme.md
 # readme.txt
@@ -22,10 +19,14 @@ echo "TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH"
 # dir/readme.md
 # dir/anotherdir/readme.md
 # dir.md/anotherdir/readme.md
-git diff --name-only $BASE_BRANCH | grep --regexp="\.md$" | grep --regexp="^.*/" > changed-files.txt
+git diff --name-only $BASE_BRANCH_SHA | grep --regexp="\.md$" | grep --regexp="^.*/" > changed-files.txt
 
-echo "These are changed files:"
-cat changed-files.txt
+if [ `cat changed-files.txt | wc -l` -ge 0 ]; then
+    echo "There are no GitBook MarkDown files to check."
+else
+    echo "These files need to be checked:"
+    cat changed-files.txt
+fi
 
 EXIT_CODE=0
 # read an individual line from the changed-files.txt file

--- a/blc-on-changed-files.sh
+++ b/blc-on-changed-files.sh
@@ -21,7 +21,7 @@ BASE_BRANCH_SHA=`git rev-parse origin/$BASE_BRANCH`
 # dir.md/anotherdir/readme.md
 git diff --name-only $BASE_BRANCH_SHA | grep --regexp="\.md$" | grep --regexp="^.*/" > changed-files.txt
 
-if [ `cat changed-files.txt | wc -l` -ge 0 ]; then
+if [ `cat changed-files.txt | wc -l` -eq 0 ]; then
     echo "There are no GitBook MarkDown files to check."
 else
     echo "These files need to be checked:"

--- a/blc-on-changed-files.sh
+++ b/blc-on-changed-files.sh
@@ -18,7 +18,10 @@ GITBOOK_LOCATION='http://localhost:4000'
 # dir/readme.md
 # dir/anotherdir/readme.md
 # dir.md/anotherdir/readme.md
-git diff --name-only $BASE_BRANCH...$CURRENT_BRANCH | grep --regexp="\.md$" | grep --regexp="^.*/" > changed-files.txt
+git diff --name-only $BASE_BRANCH | grep --regexp="\.md$" | grep --regexp="^.*/" > changed-files.txt
+
+echo "These are changed files:"
+cat changed-files.txt
 
 EXIT_CODE=0
 # read an individual line from the changed-files.txt file

--- a/blc-on-changed-files.sh
+++ b/blc-on-changed-files.sh
@@ -4,6 +4,10 @@ BASE_BRANCH='master'
 CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 GITBOOK_LOCATION='http://localhost:4000'
 
+echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
+echo "TRAVIS_PULL_REQUEST_SHA=$TRAVIS_PULL_REQUEST_SHA"
+echo "TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH"
+
 # If the git diff result below is something like:
 # readme.md
 # readme.txt

--- a/blc-on-changed-files.sh
+++ b/blc-on-changed-files.sh
@@ -4,15 +4,36 @@ BASE_BRANCH='master'
 CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 GITBOOK_LOCATION='http://localhost:4000'
 
-git diff --name-only $BASE_BRANCH...$CURRENT_BRANCH > changed-files.txt
+# If the git diff result below is something like:
+# readme.md
+# readme.txt
+# dir/readme.txt
+# dir/readme.md
+# dir/anotherdir/readme.md
+# dir/anotherdir/readme.txt
+# dir.md/anotherdir/readme.md
+# dir.md/anotherdir/readme.txt
+#
+# the grepping should filter it down to
+# dir/readme.md
+# dir/anotherdir/readme.md
+# dir.md/anotherdir/readme.md
+git diff --name-only $BASE_BRANCH...$CURRENT_BRANCH | grep --regexp="\.md$" | grep --regexp="^.*/" > changed-files.txt
 
 EXIT_CODE=0
+# read an individual line from the changed-files.txt file
 while read line;
 do 
+    # Use awk to find and replace the filename extension .md with .html,
+    # concatenate with the gitbook server location, feed that to
+    # broken-link-checker via its 'input' argument
     blc --input `echo $GITBOOK_LOCATION/$line | awk '{ gsub(".md$",".html",$1); print $1 }'`;
+    # Take note of the success or failure of the blc command.
     if [ $? -ne 0 ]; then
         EXIT_CODE=1
     fi
 done < changed-files.txt
 
+# If any failures have occurred during the above while loop, exit with a failure
+# code (1), otherwise, exit with a success code (0).
 exit $EXIT_CODE

--- a/blc-on-changed-files.sh
+++ b/blc-on-changed-files.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+BASE_BRANCH='master'
+CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+GITBOOK_LOCATION='http://localhost:4000'
+
+git diff --name-only $BASE_BRANCH...$CURRENT_BRANCH > changed-files.txt
+
+EXIT_CODE=0
+while read line;
+do 
+    blc --input `echo $GITBOOK_LOCATION/$line | awk '{ gsub(".md$",".html",$1); print $1 }'`;
+    if [ $? -ne 0 ]; then
+        EXIT_CODE=1
+    fi
+done < changed-files.txt
+
+exit $EXIT_CODE


### PR DESCRIPTION
- [x] I followed the [CONTRIBUTING guidelines](../blob/master/CONTRIBUTING.md).

Below, describe what this Pull Request adds:

Run broken link checker only on the subset of files that have changed AND that are markdown files AND that are part of the GitBook. Hopefully helps to resolve the discussion [here](https://github.com/NLeSC/guide/pull/155)  and [here](https://github.com/NLeSC/guide/pull/153).

Seems to work: https://travis-ci.org/NLeSC/guide/builds/408558626

Maybe we can run the setup from [#155](https://github.com/NLeSC/guide/pull/155) in a cron job, while running this setup on PRs.


