### PR TITLE
Replace 'here' as link text with more meaningful text

### DIFF
--- a/best_practices/code_quality.md
+++ b/best_practices/code_quality.md
@@ -24,10 +24,10 @@ from the style of choice and helps to avoid some problems caused by formatting d
 (line ending, tabs vs spaces).
 
 There is support for editorconfig in most editors.
-[Here](http://editorconfig.org/) you can download plugins for your editor of choice.
+The [Editorconfig website](http://editorconfig.org/) provides plugins for your editor of choice.
 If you use eclipse, use [this plugin](https://github.com/ncjones/editorconfig-eclipse).
 
-The eScience Center editor config file can be downloaded [here](https://raw.githubusercontent.com/NLeSC/exemplum/master/.editorconfig)
+The eScience Center has a [shared editor config file](https://raw.githubusercontent.com/NLeSC/exemplum/master/.editorconfig)
 
 ## Automatic code formatters and linters
 

--- a/best_practices/documentation.md
+++ b/best_practices/documentation.md
@@ -88,7 +88,7 @@ file describes at least how to perform the following tasks:
 - What [code style](code_quality.html#coding-style) to use
 - Reference to [code of conduct](#code-of-conduct)
 - When using a [git branching model](version_control.html#choose-one-branching-model), the choice of branching model
-An extensive example can be found [here](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md). [Note that GitHub has built in support for a CONTRIBUTING.md file](https://github.com/blog/1184-contributing-guidelines).
+An extensive example is [Angular.js's CONTRIBUTING.md](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md). Note that [GitHub has built in support for a CONTRIBUTING.md file](https://github.com/blog/1184-contributing-guidelines).
 
 ## Code of conduct
 

--- a/best_practices/language_guides/java.md
+++ b/best_practices/language_guides/java.md
@@ -19,7 +19,7 @@ For Java we normally use the [Eclipse](https://www.eclipse.org/) IDE.
 
 We follow the standard coding style defined by SUN.
 
-Latest version seems to be available [here](https://www.scribd.com/doc/15884743/Java-Coding-Style-by-Achut-Reddy).
+Latest version seems to be the [Java Coding Style on Scribd](https://www.scribd.com/doc/15884743/Java-Coding-Style-by-Achut-Reddy).
 
 We have standard code formatting settings for eclipse.
 
@@ -102,4 +102,4 @@ repositories {
 }
 ```
 
-Packages developed at the Netherlands eScience Center can be found [here](https://bintray.com/nlesc).
+Packages developed at the Netherlands eScience Center can be found in the [Bintray NLeSC repository](https://bintray.com/nlesc).

--- a/best_practices/language_guides/javascript.md
+++ b/best_practices/language_guides/javascript.md
@@ -115,7 +115,7 @@ Then open the webbrowser to &#104;ttp://localhost:8000.
 
 # Documentation
 
-[JSDoc](http://usejsdoc.org/) works similarly to JavaDoc, in that it parses your JavaScript files and automatically generates HTML documentation. [Here](http://usejsdoc.org/#JSDoc3_Tag_Dictionary) is an overview of the tag names you can use to document your code.
+[JSDoc](http://usejsdoc.org/) works similarly to JavaDoc, in that it parses your JavaScript files and automatically generates HTML documentation. The [Tag Dictionary](http://usejsdoc.org/#JSDoc3_Tag_Dictionary) is an overview of the tag names you can use to document your code.
 
 # Testing
 

--- a/best_practices/language_guides/python.md
+++ b/best_practices/language_guides/python.md
@@ -198,7 +198,7 @@ The default location to put HTML documentation is [Read the Docs](https://readth
 There are several tools that automatically generate documentation from docstrings. These are the most used:
 * [pydoc](https://docs.python.org/2/library/pydoc.html)
 * [Sphinx](http://sphinx-doc.org) (uses reStructuredText as its markup language)
-  * [sphinx tutorial](http://www.sphinx-doc.org/en/stable/tutorial.html)
+  * [Sphinx quickstart](http://www.sphinx-doc.org/en/master/usage/quickstart.html)
   * [Restructured Text (reST) and Sphinx CheatSheet](http://openalea.gforge.inria.fr/doc/openalea/doc/_build/html/source/sphinx/rest_syntax.html)
   * Instead of using reST, Sphinx can also generate documentation from the more readable [NumPy style](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt) or [Google style](https://google.github.io/styleguide/pyguide.html) docstrings. The [Napoleon extension](http://sphinxcontrib-napoleon.readthedocs.io/) needs to be enabled.
 

--- a/best_practices/language_guides/python.md
+++ b/best_practices/language_guides/python.md
@@ -67,8 +67,8 @@ A possible downside of Anaconda is the fact that this is offered by a commercial
 ## Editors and IDEs
 
 * Every major text editor supports Python, either natively or through plugins. At the Netherlands eScience Center, often used editors are [atom](https://atom.io/), [Sublime Text](https://www.sublimetext.com/) and [vim](https://realpython.com/blog/python/vim-and-python-a-match-made-in-heaven/).
-* [PyDev](http://www.pydev.org/) is an open source IDE. The source code is available [here](https://github.com/fabioz/Pydev). It has debugging, unit testing, and reporting(code analysis, code coverage) support.
-* For those seeking an IDE, JetBrains [PyCharm](https://www.jetbrains.com/pycharm/) is the Python IDE of choice. [PyCharm Community Edition](https://www.jetbrains.com/pycharm)  is open source. The source code is available [here](https://github.com/JetBrains/intellij-community/tree/master/python). It has visual debugger, unit testing and code coverage support, profiler. List of other tools can be found [here](https://www.jetbrains.com/pycharm/features/tools.html).
+* [PyDev](http://www.pydev.org/) is an open source IDE. The source code is available in the [PyDev GitHub repository](https://github.com/fabioz/Pydev). It has debugging, unit testing, and reporting(code analysis, code coverage) support.
+* For those seeking an IDE, JetBrains [PyCharm](https://www.jetbrains.com/pycharm/) is the Python IDE of choice. [PyCharm Community Edition](https://www.jetbrains.com/pycharm)  is open source. The source code is available in the [python folder of the IntelliJ repository](https://github.com/JetBrains/intellij-community/tree/master/python). It has visual debugger, unit testing and code coverage support, profiler. JetBrains provides a [list of all tools in PyCharm](https://www.jetbrains.com/pycharm/features/tools.html).
 
 ## Coding style conventions
 
@@ -82,7 +82,7 @@ Many linters exists for Python, [`prospector`](https://github.com/landscapeio/pr
 * [mccabe](https://github.com/PyCQA/mccabe)
 * [pyroma](https://github.com/regebro/pyroma)
 
-Make sure to set strictness to `veryhigh` for best results. `prospector` has it's own configuration file, see [here](https://github.com/benvanwerkhoven/empty_python/blob/master/.prospector.yml) for an example, but also supports configuration files for any of the linters that it runs. Most of the above tools can be integrated in text editors and IDEs for convenience.
+Make sure to set strictness to `veryhigh` for best results. `prospector` has its own configuration file, like [Ben van Werkhoven's .prospector.yml example](https://github.com/benvanwerkhoven/empty_python/blob/master/.prospector.yml), but also supports configuration files for any of the linters that it runs. Most of the above tools can be integrated in text editors and IDEs for convenience.
 
 ## Building and packaging code
 
@@ -111,7 +111,7 @@ framework available in Python Standard Library.
 
 Using `pytest` is preferred over `unittest`, `pytest` has a much more concise syntax and supports many useful features.
 
-Please make sure the command `python setup.py test` can be used to run your tests. When using `pytest`, this can be easily configured as described [here](https://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner).
+Please make sure the command `python setup.py test` can be used to run your tests. When using `pytest`, this can be easily configured as described in the [`pytest` documentation](https://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner).
 
 ### Code coverage
 
@@ -160,7 +160,7 @@ For example project see https://landscape.io/github/NLeSC/MAGMa
 * If you are using Windows, [Python Tools for Visual Studio](https://github.com/Microsoft/PTVS) adds Python support for Visual Studio.
 * If you would like to integrate [pdb](https://docs.python.org/3/library/pdb.html) with **vim** editor, you can use [Pyclewn](https://sourceforge.net/projects/pyclewn).
 
-* List of other available software can be found [here](https://wiki.python.org/moin/PythonDebuggingTools).
+* List of other available software can be found on the [Python wiki page on debugging tools](https://wiki.python.org/moin/PythonDebuggingTools).
 
 * If you are looking for some tutorials to get started:
     - https://pymotw.com/2/pdb

--- a/best_practices/language_guides/python.md
+++ b/best_practices/language_guides/python.md
@@ -82,7 +82,7 @@ Many linters exists for Python, [`prospector`](https://github.com/landscapeio/pr
 * [mccabe](https://github.com/PyCQA/mccabe)
 * [pyroma](https://github.com/regebro/pyroma)
 
-Make sure to set strictness to `veryhigh` for best results. `prospector` has its own configuration file, like [Ben van Werkhoven's .prospector.yml example](https://github.com/benvanwerkhoven/empty_python/blob/master/.prospector.yml), but also supports configuration files for any of the linters that it runs. Most of the above tools can be integrated in text editors and IDEs for convenience.
+Make sure to set strictness to `veryhigh` for best results. `prospector` has its own configuration file, like the [.prospector.yml default in the Python template](https://github.com/NLeSC/python-template/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/.prospector.yml), but also supports configuration files for any of the linters that it runs. Most of the above tools can be integrated in text editors and IDEs for convenience.
 
 ## Building and packaging code
 

--- a/best_practices/language_guides/r.md
+++ b/best_practices/language_guides/r.md
@@ -26,14 +26,14 @@ R programs can be written in any text editor. R code can be run from the command
 Within RStudio you can work on ad-hoc code or create a project. Compared with Python an R project is a bit like a virtual environment as it preserves the workspace and installed packages for that project. Creating a project is needed to build an R package. A project is created via the menu at the top of the screen.
 
 ### Installing compilers and runtimes
-Not needed as most functions in R are already compiled in C, nevertheless R has compiling functionality see [here](https://stat.ethz.ch/R-manual/R-devel/library/compiler/html/compile.html). See overview by Hadley Wickham [here](http://r-pkgs.had.co.nz/src.html).
+Not needed as most functions in R are already compiled in C, nevertheless R has compiling functionality as described in the [R manual](https://stat.ethz.ch/R-manual/R-devel/library/compiler/html/compile.html). See [overview by Hadley Wickham](http://r-pkgs.had.co.nz/src.html).
 
 # Coding style conventions
 It is good to follow the R style conventions as [posted](http://adv-r.had.co.nz/Style.html) by Hadley Wickham, which is seems compatible with the R style convention as posted by [Google](https://google.github.io/styleguide/Rguide.xml).
 
 One point in both style conventions that has resulted in some discussion is the '<-' syntax for variable assignment. In the majority of R tutorials and books you will see that authors use this syntax, e.g. 'a <- 3' to assign value 3 to object 'a'. Please note that R syntax 'a = 3' will preform exactly the same operation in 99.9% of situations. The = syntax has less keystrokes and could therefore be considered more efficient and readable. Further, the = syntax avoids the risk for typos like a < -1, which will produce a boolean if 'a' exists, and a <- 1 which will produce an object 'a' with a numeric value. Further, the = syntax may be more natural for those who already use it in other computing languages.
 
-The difference between '<-' and '=' is mainly related to scoping, for an official R definition look [here](https://stat.ethz.ch/R-manual/R-devel/library/base/html/assignOps.html). The example below demonstrates the difference in behaviour:
+The difference between '<-' and '=' is mainly related to scoping. See the [official R definition](https://stat.ethz.ch/R-manual/R-devel/library/base/html/assignOps.html) for more information. The example below demonstrates the difference in behaviour:
 
 Define a simple function named addone to add 1 to the function input:
 - addone = function(x) return(x + 1)
@@ -55,7 +55,7 @@ From a computer science perspective it is probably best to adhere to the <- conv
 ## Plotting with basic functions and ggplot2 and ggvis
 For a generic impression of what R can do see: http://www.r-graph-gallery.com/all-graphs/
 
-The basic R installation comes with a wide range of functions to plot data to a window on your screen or to a file. If you need to quickly inspect your data or create a custom-made static plot then the basic functions offer the building blocks to do the job. A tutorial with some examples of plotting optins in R can be found [here](http://www.statmethods.net/graphs/index.html).
+The basic R installation comes with a wide range of functions to plot data to a window on your screen or to a file. If you need to quickly inspect your data or create a custom-made static plot then the basic functions offer the building blocks to do the job. There is a [Statmethods.net tutorial with some examples of plotting options in R](http://www.statmethods.net/graphs/index.html).
 
 However, externally contributed plotting packages may offer easier syntax or convenient templates for creating plots. The most popular and powerful contributed graphics package is [ggplot2](http://ggplot2.org). Interactive plots can be made with [ggvis](https://github.com/rstudio/ggvis) package and embeded in web application, and this [tutorial](http://www.statmethods.net/advgraphs/ggplot2.html).
 

--- a/best_practices/licensing.md
+++ b/best_practices/licensing.md
@@ -55,7 +55,7 @@ NOTICE should contain the following text, adapted with the product's name and co
 ```
 
 If any of the software dependencies has a NOTICE file, its contents shoud be appended below.
-Read more [here](http://www.apache.org/dev/licensing-howto.html)
+Read more in the [ASF licensing how-to](http://www.apache.org/dev/licensing-howto.html).
 
 ## Modifying existing software
 

--- a/best_practices/releases.md
+++ b/best_practices/releases.md
@@ -48,7 +48,7 @@ If your software is useful for a wider audience, create a package that can be in
 * C, C++, Fortran, ... use packages from your distributions official repository. List your actual dependencies in the *INSTALL.md* or *README.md*
 
 Some standard solutions for building (compiling) code are:
-* The Autotools: _autoconf_, _automake_, and _libtool_. Documentation can be found [here](https://www.gnu.org/software/automake/manual/html_node/Autotools-Introduction.html), or some introductionary presentation [here](https://elinux.org/images/4/43/Petazzoni.pdf)
+* The Autotools: _autoconf_, _automake_, and _libtool_. See the [Autotools Documentation](https://www.gnu.org/software/automake/manual/html_node/Autotools-Introduction.html), or an [introductionary presentation by Thomas Petazzoni](https://elinux.org/images/4/43/Petazzoni.pdf)
 * [CMake](https://cmake.org/)
 * [Make](https://www.gnu.org/software/make/)
 

--- a/best_practices/version_control.md
+++ b/best_practices/version_control.md
@@ -97,9 +97,7 @@ there are competitiveness issues) it should be in a public online repository. In
 case the code uses data that cannot be open, an engineer should try to keep
 sensitive parts outside of the main codebase. If you accidentally included
 copyrighted files in your repository, you need to remove them from the HEAD as
-well as from history. There is a gist
-[here](https://gist.github.com/jspaaks/df292d42ecbd5e28d4620f011c602b90) that
-explains how.
+well as from history. There is a [gist that explains how](https://gist.github.com/jspaaks/df292d42ecbd5e28d4620f011c602b90).
 
 ## Meaningful commit messages
 

--- a/nlesc_specific/e-infrastructure/e-infrastructure.md
+++ b/nlesc_specific/e-infrastructure/e-infrastructure.md
@@ -28,7 +28,7 @@ The Netherlands eScience Center also has access to the infrastructure provided b
 
 ### Available systems at SURF
 
-Here we list some of the most likely to be used resources at SURF. See [this site](https://www.surf.nl/en/services-and-products) for an overview all SURF services and products, and [here](https://userinfo.surfsara.nl/systems) for detailed information on the SURFsara infrastructure.
+Here we list some of the most likely to be used resources at SURF. See the [overview of all SURF services and products](https://www.surf.nl/en/services-and-products), and [detailed information on the SURFsara infrastructure](https://userinfo.surfsara.nl/systems).
 
 SURFsara:
 
@@ -60,8 +60,8 @@ Any eScience Center employee can get a DAS-5 account, usually available within a
 
 ## Security and convenience when committing code to GitHub from a cluster
 
-When accessing a cluster, it is generally [safer to use a pair of keys than to login using a username and password](https://superuser.com/questions/303358/why-is-ssh-key-authentication-better-than-password-authentication). [Here](https://www.cyberciti.biz/faq/how-to-set-up-ssh-keys-on-linux-unix/) is a guide on how to setup those keys. Make sure you encrypt your private key and that it is not automatically decrypted when you login to your local machine.
-Make a separate pair of keys to access your GitHub account following [these](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/) instructions. It involves [uploading your public key to your GitHub account](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/) and [testing](https://help.github.com/articles/testing-your-ssh-connection/).
+When accessing a cluster, it is generally [safer to use a pair of keys than to login using a username and password](https://superuser.com/questions/303358/why-is-ssh-key-authentication-better-than-password-authentication). There is a [guide on how to setup those keys](https://www.cyberciti.biz/faq/how-to-set-up-ssh-keys-on-linux-unix/). Make sure you encrypt your private key and that it is not automatically decrypted when you login to your local machine.
+Make a separate pair of keys to access your GitHub account following [GitHub's instructions](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/). It involves [uploading your public key to your GitHub account](https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/) and [testing your connection](https://help.github.com/articles/testing-your-ssh-connection/).
 
 When committing code from a cluster to GitHub, one needs to store an encrypted private key in the $HOME/.ssh directory on the cluster. This is inconvenient, because it requires submitting a password to unlock the private key. This password has to be resubmitted when SSHing to a local node from the head node. To bypass this inconvenience [SSH agent forwarding](https://developer.github.com/guides/using-ssh-agent-forwarding/) is recommended. It is very simple. On your local machine, make a $HOME/.ssh/config file to contain the following:
 ```


### PR DESCRIPTION
- [x] I followed the [CONTRIBUTING guidelines](../blob/master/CONTRIBUTING.md).

http://blog.securem.eu/tips%20and%20tricks/2016/02/29/creating-and-publishing-a-python-module/ is broken in that the host is unknown.

Below, describe what this Pull Request adds:

In an effort to follow up on #173 this PR rephrases some sentences and replaces link texts to make them more descriptive. This means you shouldn't have to inspect the URL to understand where the link leads. In this PR I mainly focused on 'here'; there are a few other link texts that could be replaced like 'this site'.
 
