### PR TITLE
updated the xenon links 'NLeSC/Xenon' to 'xenon-middleware/xenon'

### DIFF
--- a/best_practices/language_guides/java.md
+++ b/best_practices/language_guides/java.md
@@ -60,12 +60,12 @@ Notifications of each project must be configured in your own account settings.
 
 Code quality and coverage grouped by file.
 Can setup goals to improve quality or coverage by file or category.
-For example project see https://www.codacy.com/app/NLeSC/Xenon/dashboard
+For example project see https://www.codacy.com/app/xenon-middleware/xenon/dashboard
 
 ### [Codecov](https://codecov.io)
 Can show code coverages for many languages including Java, Python and Javascript.
 Shows unified coverage and separate coverage for matrix builds.
-For example project see https://codecov.io/github/NLeSC/Xenon
+For example project see https://codecov.io/github/xenon-middleware/xenon
 
 ## Debugging and Profiling
 
@@ -87,7 +87,7 @@ Java has the inbuild [JavaDoc](http://www.oracle.com/technetwork/java/javase/doc
 
 ## Available Templates
 
-There are currently no Java templates available. See [The Xenon repo on GitHub](https://github.com/nlesc/xenon) as an (rather complex) example.
+There are currently no Java templates available. See [The Xenon repo on GitHub](https://github.com/xenon-middleware/xenon) as a (rather complex) example.
 
 ## Distribution
 

--- a/best_practices/testing.md
+++ b/best_practices/testing.md
@@ -79,7 +79,7 @@ Below is a short list of services and their strengths.
 #### [Codecov](https://codecov.io)
 
 Shows unified coverage and separate coverage for [build matrix](https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix) e.g. different Python versions.
-For example project see https://codecov.io/gh/NLeSC/Xenon, with a Java 7/8 and Linux/Windows/OSX OS build matrix.
+For example project see https://codecov.io/gh/xenon-middleware/xenon, with a Java 7/8 and Linux/Windows/OSX OS build matrix.
 
 #### [Coveralls](https://coveralls.io)
 


### PR DESCRIPTION
- [x] I followed the [CONTRIBUTING guidelines](../blob/master/CONTRIBUTING.md).

Below, describe what this Pull Request adds:

fixed links to recetnly moved xenon repo 


 
