### PR TITLE
Mention black, remove autopep8

### DIFF
--- a/best_practices/language_guides/python.md
+++ b/best_practices/language_guides/python.md
@@ -72,7 +72,7 @@ A possible downside of Anaconda is the fact that this is offered by a commercial
 
 ## Coding style conventions
 
-The style guide for Python code is [PEP8](http://www.python.org/dev/peps/pep-0008/) and for docstrings it is [PEP257](https://www.python.org/dev/peps/pep-0257/). The `autopep8` package can automatically format most Python code to conform to the PEP 8 style guide. The more comprehensive [`yapf`](https://github.com/google/yapf) tool can automatically format code for optimal readability according to a chosen style (PEP 8 is the default). The [`isort`](http://timothycrosley.github.io/isort/) package automatically formats and groups all imports in a standard, readable way.
+The style guide for Python code is [PEP8](http://www.python.org/dev/peps/pep-0008/) and for docstrings it is [PEP257](https://www.python.org/dev/peps/pep-0257/). Tools like [`black`](https://black.readthedocs.io/en/stable/index.html) and  [`yapf`](https://github.com/google/yapf) can automatically format code for optimal readability. The [`isort`](http://timothycrosley.github.io/isort/) package automatically formats and groups all imports in a standard, readable way.
 
 Many linters exists for Python, [`prospector`](https://github.com/landscapeio/prospector) is a tool for running a suite of linters, it supports, among others:
 * [pycodestyle](https://github.com/PyCQA/pycodestyle)


### PR DESCRIPTION
- [x] I followed the [CONTRIBUTING guidelines](../blob/master/CONTRIBUTING.md).

Mention `black` for automatically formatting Python code and remove `autopep8`, since it's less popular.
 
