### PR TITLE
Expand slightly on yapf vs black

### DIFF
--- a/best_practices/language_guides/python.md
+++ b/best_practices/language_guides/python.md
@@ -72,7 +72,7 @@ A possible downside of Anaconda is the fact that this is offered by a commercial
 
 ## Coding style conventions
 
-The style guide for Python code is [PEP8](http://www.python.org/dev/peps/pep-0008/) and for docstrings it is [PEP257](https://www.python.org/dev/peps/pep-0257/). Tools like [`black`](https://black.readthedocs.io/en/stable/index.html) and  [`yapf`](https://github.com/google/yapf) can automatically format code for optimal readability. The [`isort`](http://timothycrosley.github.io/isort/) package automatically formats and groups all imports in a standard, readable way.
+The style guide for Python code is [PEP8](http://www.python.org/dev/peps/pep-0008/) and for docstrings it is [PEP257](https://www.python.org/dev/peps/pep-0257/). Tools like [`yapf`](https://github.com/google/yapf) and [`black`](https://black.readthedocs.io/en/stable/index.html) can automatically format code for optimal readability. `yapf` is configurable to suit your (team's) preferences, whereas `black` enforces one particular style chosen by the `black` authors. The [`isort`](http://timothycrosley.github.io/isort/) package automatically formats and groups all imports in a standard, readable way.
 
 Many linters exists for Python, [`prospector`](https://github.com/landscapeio/prospector) is a tool for running a suite of linters, it supports, among others:
 * [pycodestyle](https://github.com/PyCQA/pycodestyle)

--- a/best_practices/language_guides/python.md
+++ b/best_practices/language_guides/python.md
@@ -72,7 +72,7 @@ A possible downside of Anaconda is the fact that this is offered by a commercial
 
 ## Coding style conventions
 
-The style guide for Python code is [PEP8](http://www.python.org/dev/peps/pep-0008/) and for docstrings it is [PEP257](https://www.python.org/dev/peps/pep-0257/). Tools like [`yapf`](https://github.com/google/yapf) and [`black`](https://black.readthedocs.io/en/stable/index.html) can automatically format code for optimal readability. `yapf` is configurable to suit your (team's) preferences, whereas `black` enforces one particular style chosen by the `black` authors. The [`isort`](http://timothycrosley.github.io/isort/) package automatically formats and groups all imports in a standard, readable way.
+The style guide for Python code is [PEP8](http://www.python.org/dev/peps/pep-0008/) and for docstrings it is [PEP257](https://www.python.org/dev/peps/pep-0257/). Tools like [`yapf`](https://github.com/google/yapf) and [`black`](https://black.readthedocs.io/en/stable/index.html) can automatically format code for optimal readability. `yapf` is configurable to suit your (team's) preferences, whereas `black` enforces the style chosen by the `black` authors. The [`isort`](http://timothycrosley.github.io/isort/) package automatically formats and groups all imports in a standard, readable way.
 
 Many linters exists for Python, [`prospector`](https://github.com/landscapeio/prospector) is a tool for running a suite of linters, it supports, among others:
 * [pycodestyle](https://github.com/PyCQA/pycodestyle)

--- a/best_practices/language_guides/python.md
+++ b/best_practices/language_guides/python.md
@@ -72,7 +72,9 @@ A possible downside of Anaconda is the fact that this is offered by a commercial
 
 ## Coding style conventions
 
-The style guide for Python code is [PEP8](http://www.python.org/dev/peps/pep-0008/) and for docstrings it is [PEP257](https://www.python.org/dev/peps/pep-0257/). Tools like [`yapf`](https://github.com/google/yapf) and [`black`](https://black.readthedocs.io/en/stable/index.html) can automatically format code for optimal readability. `yapf` is configurable to suit your (team's) preferences, whereas `black` enforces the style chosen by the `black` authors. The [`isort`](http://timothycrosley.github.io/isort/) package automatically formats and groups all imports in a standard, readable way.
+The style guide for Python code is [PEP8](http://www.python.org/dev/peps/pep-0008/) and for docstrings it is [PEP257](https://www.python.org/dev/peps/pep-0257/). We highly recommend following these conventions, as they are widely agreed upon to improve readability. To make following them significantly easier, we also recommend using either an autoformatter or a linter.
+
+Autoformatting tools like [`yapf`](https://github.com/google/yapf) and [`black`](https://black.readthedocs.io/en/stable/index.html) can automatically format code for optimal readability. `yapf` is configurable to suit your (team's) preferences, whereas `black` enforces the style chosen by the `black` authors. The [`isort`](http://timothycrosley.github.io/isort/) package automatically formats and groups all imports in a standard, readable way.
 
 Many linters exists for Python, [`prospector`](https://github.com/landscapeio/prospector) is a tool for running a suite of linters, it supports, among others:
 * [pycodestyle](https://github.com/PyCQA/pycodestyle)

--- a/best_practices/language_guides/python.md
+++ b/best_practices/language_guides/python.md
@@ -74,8 +74,6 @@ A possible downside of Anaconda is the fact that this is offered by a commercial
 
 The style guide for Python code is [PEP8](http://www.python.org/dev/peps/pep-0008/) and for docstrings it is [PEP257](https://www.python.org/dev/peps/pep-0257/). We highly recommend following these conventions, as they are widely agreed upon to improve readability. To make following them significantly easier, we recommend using a linter.
 
-Autoformatting tools like [`yapf`](https://github.com/google/yapf) and [`black`](https://black.readthedocs.io/en/stable/index.html) can automatically format code for optimal readability. `yapf` is configurable to suit your (team's) preferences, whereas `black` enforces the style chosen by the `black` authors. The [`isort`](http://timothycrosley.github.io/isort/) package automatically formats and groups all imports in a standard, readable way.
-
 Many linters exists for Python, [`prospector`](https://github.com/landscapeio/prospector) is a tool for running a suite of linters, it supports, among others:
 * [pycodestyle](https://github.com/PyCQA/pycodestyle)
 * [pydocstyle](https://github.com/PyCQA/pydocstyle)
@@ -85,6 +83,8 @@ Many linters exists for Python, [`prospector`](https://github.com/landscapeio/pr
 * [pyroma](https://github.com/regebro/pyroma)
 
 Make sure to set strictness to `veryhigh` for best results. `prospector` has its own configuration file, like the [.prospector.yml default in the Python template](https://github.com/NLeSC/python-template/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/.prospector.yml), but also supports configuration files for any of the linters that it runs. Most of the above tools can be integrated in text editors and IDEs for convenience.
+
+Autoformatting tools like [`yapf`](https://github.com/google/yapf) and [`black`](https://black.readthedocs.io/en/stable/index.html) can automatically format code for optimal readability. `yapf` is configurable to suit your (team's) preferences, whereas `black` enforces the style chosen by the `black` authors. The [`isort`](http://timothycrosley.github.io/isort/) package automatically formats and groups all imports in a standard, readable way.
 
 ## Building and packaging code
 

--- a/best_practices/language_guides/python.md
+++ b/best_practices/language_guides/python.md
@@ -72,7 +72,7 @@ A possible downside of Anaconda is the fact that this is offered by a commercial
 
 ## Coding style conventions
 
-The style guide for Python code is [PEP8](http://www.python.org/dev/peps/pep-0008/) and for docstrings it is [PEP257](https://www.python.org/dev/peps/pep-0257/). We highly recommend following these conventions, as they are widely agreed upon to improve readability. To make following them significantly easier, we also recommend using either an autoformatter or a linter.
+The style guide for Python code is [PEP8](http://www.python.org/dev/peps/pep-0008/) and for docstrings it is [PEP257](https://www.python.org/dev/peps/pep-0257/). We highly recommend following these conventions, as they are widely agreed upon to improve readability. To make following them significantly easier, we recommend using a linter.
 
 Autoformatting tools like [`yapf`](https://github.com/google/yapf) and [`black`](https://black.readthedocs.io/en/stable/index.html) can automatically format code for optimal readability. `yapf` is configurable to suit your (team's) preferences, whereas `black` enforces the style chosen by the `black` authors. The [`isort`](http://timothycrosley.github.io/isort/) package automatically formats and groups all imports in a standard, readable way.
 


### PR DESCRIPTION
- [x] I followed the [CONTRIBUTING guidelines](../blob/master/CONTRIBUTING.md).

This PR adds a sentence to explain the main difference between yapf and black: configurability.

Disclaimer (which probably shows in my phrasing): I really don't like the way black splits up comma separated lines. I am all for keeping important lines as short as possible for readability. However, some parts of code are not really semantically that meaningful, like for instance long import lists, or long lists of numbers or constants or, many times, function calls with many arguments, especially those with many keyword arguments where the mapping of keywords to local variables is often trivial (i.e. `bla=bla_local`, `ding=ding_here`, etc). When black splits up these lines from say:

```python
from sqlalchemy import Column, String, Table, ForeignKey, Unicode, Boolean, Integer, BigInteger, ForeignKeyConstraint
```

which most people would read as "ok, stuff from sqlalchemy, I get it, whatever", to this:

```python
from sqlalchemy import (
    Column,
    String,
    Table,
    ForeignKey,
    Unicode,
    Boolean,
    Integer,
    BigInteger,
    ForeignKeyConstraint,
)
```

which takes up a quarter of my editor's screen, implicitly screaming "I AM IMPORTANT", it really messes up the flow of reading the code. I have to scroll a lot more to see all the important parts of the code on my screen. Bad. And, in fact, the whole point of the operation, to make lines shorter, is not actually performed at all. In fact, the line is taking up way more screen space this way. A better way to make a line shorter is to change the code such that less has to be written on the line. For instance, use functions with less arguments, or just `import sqlalchemy` instead of all its subcomponents separately (which will lengthen other lines, for sure, but using a namespace has other benefits), etc.

Anyway, before this turns into a rant (oops, too late), let me just leave you with the thought that black is supposed to end these kinds of discussions once and for all. In that it succeeds, because the discussion can be replaced by the discussion of whether to use black or not ;)