### PR TITLE
Update chapter_owners.md

### DIFF
--- a/chapter_owners.md
+++ b/chapter_owners.md
@@ -2,7 +2,7 @@
 
 This is a list of who is responsible for which part of the guide.
 
-Overall Maintainer: Jason Maassen
+Overall Maintainer: Bouwe Andela
 
 * Introduction: Jason Maassen
 
@@ -13,7 +13,7 @@ Overall Maintainer: Jason Maassen
   * Introduction: Jason Maassen
   * Java: Christiaan Meijer
   * JavaScript and TypeScript: Jurriaan Spaaks
-  * Python: Janneke van der Zwaan
+  * Python: Patrick Bos
   * OpenCL and CUDA: Ben van Werkhoven
   * R: Vincent van Hees
   * C and C++: Johan Hidding and Patrick Bos


### PR DESCRIPTION
Two updates:
- Credit where credit's due: @bouweandela has been leading this thing for a year or so now, the record should reflect this (even if management may soon transfer to the SSE SIG).
- I'd like to take ownership of the Python chapter. I will do a thorough sweep soon.

- [x] I followed the [CONTRIBUTING guidelines](../blob/master/CONTRIBUTING.md).