### PR TITLE
update code quality services (for Python)

### DIFF
--- a/best_practices/code_quality.md
+++ b/best_practices/code_quality.md
@@ -1,8 +1,8 @@
 # Code Quality
 
-Ways to improve code quality are in the [Code quality](https://the-turing-way.netlify.app/code_quality/code_quality.html) chapter on the Turing Way.
+Ways to improve code quality are in the [Code quality](https://the-turing-way.netlify.app/reproducible-research/code-quality.html) chapter on the Turing Way.
 
-There are [online software quality improvement tools](https://the-turing-way.netlify.app/code_quality/code_quality.html#Online-services-providing-software-quality-checks) see the [language guides](language_guides/languages_overview.md) for good options per language.
+There are [online software quality improvement tools](https://the-turing-way.netlify.app/reproducible-research/code-quality/code-quality-style.html#online-services-providing-software-quality-checks) see the [language guides](language_guides/languages_overview.md) for good options per language.
 
 ## Editorconfig
 

--- a/best_practices/documentation.md
+++ b/best_practices/documentation.md
@@ -88,7 +88,7 @@ file describes at least how to perform the following tasks:
 
 * How to [install the dependencies](#documented-development-setup)
 * How to run [(unit) tests](testing.md#unit-tests)
-* What [code style](https://the-turing-way.netlify.app/code_quality/code_quality.html#Code-style) to use
+* What [code style](https://the-turing-way.netlify.app/reproducible-research/code-quality/code-quality-style.html) to use
 * Reference to [code of conduct](#code-of-conduct)
 * When using a [git branching model](version_control.md#choose-one-branching-model), the choice of branching model
 

--- a/best_practices/language_guides/python.md
+++ b/best_practices/language_guides/python.md
@@ -140,24 +140,11 @@ If this is not possible or does not fit then use one of the generic code coverag
 ## Code quality analysis tools and services
 
 Code quality service is explained in the [The Turing Way](https://the-turing-way.netlify.app/reproducible-research/code-quality/code-quality-style.html#online-services-providing-software-quality-checks).
-There are multiple code quality services available for Python.
-There is not a best one, below is a short list of services with their different strenghts.
-
-### [Codacy](https://www.codacy.com)
-
-Code quality and coverage grouped by file.
-Can setup goals to improve quality or coverage by file or category.
-For example project see https://www.codacy.com/app/3D-e-Chem/kripodb/dashboard.
-Note that Codacy does not install your depencencies, which prevents it from correctly identifying import errors.
-
-### [Sonarcloud](https://sonarcloud.io/)
-Provides reports similar to Codacy, but can be run from CI (e.g. GitHub Actions), which allows you to install dependencies yourself and thus provide a more complete coverage.
-This is currently the default choice in our [Python template](https://github.com/NLeSC/python-template).
-
-### [Scrutinizer](https://scrutinizer-ci.com/)
-
-Code quality and coverage grouped by class and function.
-For example project see https://scrutinizer-ci.com/g/NLeSC/eEcology-Annotation-WS/
+There are multiple code quality services available for Python, all of which have their pros and cons.
+See [The Turing Way](https://the-turing-way.netlify.app/reproducible-research/code-quality/code-quality-resources.html) for links to lists of possible services.
+We currently setup [Sonarcloud](https://sonarcloud.io/) by default in our [Python template](https://github.com/NLeSC/python-template).
+To reproduce the Sonarcloud pipeline locally, you can use [SonarLint](https://www.sonarlint.org/) in your IDE.
+If you use another editor, perhaps it is more convenient to pick another service like Codacy or Codecov.
 
 
 ## Debugging and profiling

--- a/best_practices/language_guides/python.md
+++ b/best_practices/language_guides/python.md
@@ -139,7 +139,7 @@ If this is not possible or does not fit then use one of the generic code coverag
 
 ## Code quality analysis tools and services
 
-Code quality service is explained in the [The Turing Way](https://the-turing-way.netlify.app/code_quality/code_quality.html#Online-services-providing-software-quality-checks).
+Code quality service is explained in the [The Turing Way](https://the-turing-way.netlify.app/reproducible-research/code-quality/code-quality-style.html#online-services-providing-software-quality-checks).
 There are multiple code quality services available for Python.
 There is not a best one, below is a short list of services with their different strenghts.
 
@@ -150,17 +150,15 @@ Can setup goals to improve quality or coverage by file or category.
 For example project see https://www.codacy.com/app/3D-e-Chem/kripodb/dashboard.
 Note that Codacy does not install your depencencies, which prevents it from correctly identifying import errors.
 
+### [Sonarcloud](https://sonarcloud.io/)
+Provides reports similar to Codacy, but can be run from CI (e.g. GitHub Actions), which allows you to install dependencies yourself and thus provide a more complete coverage.
+This is currently the default choice in our [Python template](https://github.com/NLeSC/python-template).
+
 ### [Scrutinizer](https://scrutinizer-ci.com/)
 
 Code quality and coverage grouped by class and function.
 For example project see https://scrutinizer-ci.com/g/NLeSC/eEcology-Annotation-WS/
 
-### [Landscape](https://landscape.io)
-
-Dedicated for Python code quality.
-Celery, Django and Flask specific behaviors.
-The Landscape analysis tool called [`prospector`](https://github.com/landscapeio/prospector) can be run locally.
-For example project see https://landscape.io/github/NLeSC/MAGMa
 
 ## Debugging and profiling
 

--- a/best_practices/testing.md
+++ b/best_practices/testing.md
@@ -57,7 +57,7 @@ At the Netherlands eScience Center we require minimum of 70% coverage.
 Setting up code coverage for a repository depends on the programming language, see the [language specific guides](language_guides/languages_overview.md) for setup instructions.
 
 The code coverage should be performed when a test suite is run as part of Continuous Integration build job.
-The code coverage results can be published on code coverage and/or [code quality services](https://the-turing-way.netlify.app/code_quality/code_quality.html#Online-services-providing-software-quality-checks).
+The code coverage results can be published on code coverage and/or [code quality services](https://the-turing-way.netlify.app/reproducible-research/code-quality/code-quality-style.html#online-services-providing-software-quality-checks).
 
 ### Code coverage services
 

--- a/nlesc_specific/checklist.md
+++ b/nlesc_specific/checklist.md
@@ -40,7 +40,7 @@ The [checklist matrix](./checklist_matrix.md) provides an indication of which it
 ## [Code Quality](../best_practices/code_quality.md)
 
 - [use editorconfig](../best_practices/code_quality.md#use-editorconfig)
-- [code style applied in automated way](https://the-turing-way.netlify.app/code_quality/code_quality.html#Automatic-formatting)
+- [code style applied in automated way](https://the-turing-way.netlify.app/reproducible-research/code-quality/code-quality-style.html#automatic-formatting)
 
 ## [Testing](../best_practices/testing.md)
 


### PR DESCRIPTION
This PR fixes links to the Turing Way sections about online code quality services, which were all broken due to some updates there.

For Python specifically:
- landscape.io doesn't exist anymore (at least over https)
- add Sonarcloud, which is the default choice in the python template