### PR TITLE
Change DOI on README to refer to all versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Dead-link checker status (does not actually build guide itself): [![Build Status](https://travis-ci.org/NLeSC/guide.svg?branch=master)](https://travis-ci.org/NLeSC/guide)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4020622.svg)](https://doi.org/10.5281/zenodo.4020622)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4020564.svg)](https://doi.org/10.5281/zenodo.4020564)
 
 # Guide
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Dead-link checker status (does not actually build guide itself): [![Build Status](https://travis-ci.org/NLeSC/guide.svg?branch=master)](https://travis-ci.org/NLeSC/guide)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4020565.svg)](https://doi.org/10.5281/zenodo.4020565)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4020622.svg)](https://doi.org/10.5281/zenodo.4020622)
 
 # Guide
 


### PR DESCRIPTION
- [x] I followed the [CONTRIBUTING guidelines](../blob/master/CONTRIBUTING.md).

The current DOI badge refers to version 0.9.0 on Zenodo. This PR changes the DOI to refer to all versions on Zenodo, and automatically show the latest.
 
