### PR TITLE
Update link checker and fix broken links

### DIFF
--- a/.github/workflows/link-checker-pr.yml
+++ b/.github/workflows/link-checker-pr.yml
@@ -9,7 +9,7 @@ jobs:
         uses: lycheeverse/lychee-action@v1.4.1
         id: lychee
         with:
-          args: "--verbose --no-progress '${{ steps.changed_files.outputs.all }}'"
+          args: --verbose --no-progress ${{ steps.changed_files.outputs.all }}
       - name: Count broken links
         run: |
             broken_max=10

--- a/.github/workflows/link-checker-pr.yml
+++ b/.github/workflows/link-checker-pr.yml
@@ -4,20 +4,16 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - id: changed_files
-        uses: jitterbit/get-changed-files@v1
+      - uses: actions/checkout@v3
       - name: Link Checker
-        uses: peter-evans/link-checker@v1
-        id: lc
+        uses: lycheeverse/lychee-action@v1.4.1
+        id: lychee
         with:
-          args: -v -t 60 -c 16 -d /github/workspace -r ${{ steps.changed_files.outputs.all }}
+          args: "--verbose --no-progress '${{ steps.changed_files.outputs.all }}'"
       - name: Count broken links
         run: |
             broken_max=10
-            broken=$(grep ERROR ./link-checker/out.md || echo "Ok")
-            broken_count=$(echo "$broken" | wc -l)
-
+            broken_count=$(printf "%d" $(grep "🚫 Errors" lychee/out.md | cut -d'|' -f3))
             if [ "$broken_count" -gt "$broken_max" ]; then
                 echo "Number of broken links (${broken_count}) exceeds maximum allowed number (${broken_max})."
                 echo "Broken links: "

--- a/.github/workflows/link-checker-pr.yml
+++ b/.github/workflows/link-checker-pr.yml
@@ -11,7 +11,7 @@ jobs:
         uses: lycheeverse/lychee-action@v1.4.1
         id: lychee
         with:
-          args: --verbose --no-progress ${{ steps.changed_files.outputs.all }}
+          args: --verbose --no-progress --exclude-all-private --exclude-mail ${{ steps.changed_files.outputs.all }}
       - name: Count broken links
         run: |
             broken_max=10

--- a/.github/workflows/link-checker-pr.yml
+++ b/.github/workflows/link-checker-pr.yml
@@ -10,6 +10,8 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.4.1
         id: lychee
+        env:
+          GITHUB_TOKEN: ${{secrets.TOKEN_GITHUB}}        
         with:
           args: --verbose --no-progress --exclude-all-private --exclude-mail ${{ steps.changed_files.outputs.all }}
       - name: Count broken links

--- a/.github/workflows/link-checker-pr.yml
+++ b/.github/workflows/link-checker-pr.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - id: changed_files
+        uses: jitterbit/get-changed-files@v1
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.4.1
         id: lychee

--- a/.github/workflows/link-checker-pr.yml
+++ b/.github/workflows/link-checker-pr.yml
@@ -13,7 +13,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.TOKEN_GITHUB}}        
         with:
-          args: --verbose --no-progress --exclude-all-private --exclude-mail ${{ steps.changed_files.outputs.all }}
+          args: ${{ steps.changed_files.outputs.all }}
       - name: Count broken links
         run: |
             broken_max=10

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -8,6 +8,8 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.4.1
         id: lychee
+        env:
+          GITHUB_TOKEN: ${{secrets.TOKEN_GITHUB}}
         with:
           args: --verbose --no-progress --exclude-all-private --exclude-mail './**/*.md'
       - name: Count broken links

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 4 * * *'  
 jobs:
   linkChecker:
     runs-on: ubuntu-latest

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -10,8 +10,6 @@ jobs:
         id: lychee
         env:
           GITHUB_TOKEN: ${{secrets.TOKEN_GITHUB}}
-        with:
-          args: --verbose --no-progress --exclude-all-private --exclude-mail './**/*.md'
       - name: Count broken links
         run: |
             broken_max=10

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -4,18 +4,14 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Link Checker
-        uses: peter-evans/link-checker@v1
-        id: lc
-        with:
-          args: -v -t 60 -c 16 -d /github/workspace -r *
+        uses: lycheeverse/lychee-action@v1.4.1
+        id: lychee
       - name: Count broken links
         run: |
             broken_max=10
-            broken=$(grep ERROR ./link-checker/out.md)
-            broken_count=$(echo "$broken" | wc -l)
-
+            broken_count=$(printf "%d" $(grep "🚫 Errors" lychee/out.md | cut -d'|' -f3))
             if [ "$broken_count" -gt "$broken_max" ]; then
                 echo "Number of broken links (${broken_count}) exceeds maximum allowed number (${broken_max})."
                 echo "Broken links: "

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -8,6 +8,8 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.4.1
         id: lychee
+        with:
+          args: --verbose --no-progress --exclude-all-private --exclude-mail './**/*.md'
       - name: Count broken links
         run: |
             broken_max=10

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,5 +1,8 @@
 name: Link Checker
-on: push
+on:
+  push:
+    branches:
+      - main
 jobs:
   linkChecker:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ To view the documentation in a web browser (default address: http://localhost:40
 To check if there are any broken links using [lychee](https://github.com/lycheeverse/lychee) in a Docker container:
 
 ```shell
-docker run --init -it -v `pwd`:/docs lycheeverse/lychee --verbose --no-progress --exclude-all-private --exclude-mail /docs
+docker run --init -it -v `pwd`:/docs lycheeverse/lychee /docs --config=docs/lychee.toml
 ```
 
 If everything works as it should, ``git add``, ``commit`` and ``push`` like normal.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ To view the documentation in a web browser (default address: http://localhost:40
 To check if there are any broken links using [lychee](https://github.com/lycheeverse/lychee) in a Docker container:
 
 ```shell
-docker run --init -it -v `pwd`:/docs lycheeverse/lychee --verbose --no-progress /docs
+docker run --init -it -v `pwd`:/docs lycheeverse/lychee --verbose --no-progress --exclude-all-private --exclude-mail /docs
 ```
 
 If everything works as it should, ``git add``, ``commit`` and ``push`` like normal.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,10 @@ python3 -m http.server 4000
 
 To view the documentation in a web browser (default address: http://localhost:4000):
 
-To check if there are any broken links using [liche](https://github.com/raviqqe/liche) in a Docker container:
+To check if there are any broken links using [lychee](https://github.com/lycheeverse/lychee) in a Docker container:
 
 ```shell
-docker run -v $PWD:/docs peterevans/liche:1.1.1 -t 60 -c 16 -d /docs -r /docs
+docker run --init -it -v `pwd`:/docs lycheeverse/lychee --verbose --no-progress /docs
 ```
 
 If everything works as it should, ``git add``, ``commit`` and ``push`` like normal.

--- a/best_practices/language_guides/javascript.md
+++ b/best_practices/language_guides/javascript.md
@@ -146,7 +146,7 @@ There's also [jsfiddle](https://jsfiddle.net/), which shows you a live preview o
 # Code quality analysis tools and services
 
 * [Code climate](https://codeclimate.com) can analyze Javascript (and Ruby, PHP). For example project see https://codeclimate.com/github/NLeSC/PattyVis
-* [Codacy](https://www.codacy.com) can analyze Java, Python, Javascript and Typescript (and CSS, PHP, Scala). The analysis for Java and Python is not as good as for Javascript. The analysis is quite slow, as it analyzes each past commit. For example project see https://www.codacy.com/app/3D-e-Chem/molviewer-tsx/dashboard
+* [Codacy](https://www.codacy.com) can analyze [many different languages](https://docs.codacy.com/getting-started/supported-languages-and-tools/) using open source tools.
 * [SonarCloud](https://sonarcloud.io) is an open platform to manage code quality which can also show code coverage and count test results over time.
 Can analyze Java (best supported), C, C++, Python, Javascript and Typescript. For example project see https://sonarcloud.io/dashboard?id=e3dchem%3Amolviewer
 
@@ -164,7 +164,7 @@ To learn about TypeScript the following resources are available:
 
 * [youtube](http://www.youtube.com/playlist?list=PLyJiOytEPs4d9QUQHHSuY3n3nBmkBuqro): tutorials playlist about TypeScript
 * [tutorial](http://www.typescriptlang.org/Tutorial) from Microsoft's TypeScript website
-* [blog post](http://www.aaron-powell.com/posts/2012-10-03-typescript-source-maps) about how TypeScript can be used with the Google Chrome/Chromium debuggers (and [presumably](http://blog.oio.de/2014/04/04/internet-explorer-11-source-map-based-debugging/) Firefox, and Internet Explorer) through the use of so-called 'source maps'. (Follow [this](http://www.codeproject.com/Articles/649271/How-to-Enable-Source-Maps-in-Firefox) link to set up source mapping for Firefox, also useful for debugging minified JavaScript code).
+* [blog post](http://www.aaron-powell.com/posts/2012-10-03-typescript-source-maps) about how TypeScript can be used with the Google Chrome/Chromium debuggers (and [presumably](https://blog.oio.de/2014/04/04/internet-explorer-11-source-map-based-debugging/) Firefox, and Internet Explorer) through the use of so-called 'source maps'. (Follow [this](http://www.codeproject.com/Articles/649271/How-to-Enable-Source-Maps-in-Firefox) link to set up source mapping for Firefox, also useful for debugging minified JavaScript code).
 * [blog post](http://www.sitepen.com/blog/2013/12/31/definitive-guide-to-typescript/) that supposedly is the definitive guide to TypeScript
 * [TypeScript Language Specification](https://github.com/microsoft/TypeScript/tree/main/doc)
 

--- a/best_practices/language_guides/python.md
+++ b/best_practices/language_guides/python.md
@@ -119,7 +119,7 @@ For packaging your code, you can either use `pip` or `conda`. Neither of them is
     * To test whether your distribution will work correctly before uploading to PyPI, you can run `python -m build` in the root of your repository. Then try installing your package with `pip install dist/<your_package>tar.gz.`
     * `python -m build` will also build [Python wheels](http://pythonwheels.com/), the current standard for [distributing](https://packaging.python.org/distributing/#wheels) Python packages. This will work out of the box for pure Python code, without C extensions. If C extensions are used, each OS needs to have its own wheel. The [manylinux](https://github.com/pypa/manylinux) Docker images can be used for building wheels compatible with multiple Linux distributions. Wheel building can be automated using GitHub Actions or another CI solution, where you can build on all three major platforms using a build matrix.
 
-* [Build using conda](http://conda.pydata.org/docs/build_tutorials.html)
+* [Build using conda](https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/index.html)
   * **Make use of [conda-forge](https://conda-forge.org/) whenever possible**, since it provides many automated build services that save you tons of work, compared to using your own conda repository. It also has a very active community for when you need help.
   * Use BioConda or custom channels (hosted on GitHub) as alternatives if need be.
 
@@ -239,7 +239,7 @@ There are several tools that automatically generate documentation from docstring
 At the eScience Center, we mostly use [Sphinx](http://sphinx-doc.org), which uses reStructuredText as its markup language, but can be extended to use Markdown as well.
 
 * [Sphinx quickstart](http://www.sphinx-doc.org/en/master/usage/quickstart.html)
-* [Restructured Text (reST) and Sphinx CheatSheet](http://openalea.gforge.inria.fr/doc/openalea/doc/_build/html/source/sphinx/rest_syntax.html)
+* [reStructuredText Primer](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html)
 * Instead of using reST, Sphinx can also generate documentation from the more readable [NumPy style](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard) or [Google style](https://google.github.io/styleguide/pyguide.html) docstrings. The [Napoleon extension](http://sphinxcontrib-napoleon.readthedocs.io/) needs to be enabled.
 
 We recommend using the Google documentation style.
@@ -289,7 +289,7 @@ It is good practice to restart the kernel and run the notebook from start to fin
 * [cx_Oracle](http://cx-oracle.sourceforge.net) enables access to [Oracle](https://www.oracle.com/database/index.html) databases
 * [monetdb.sql](https://www.monetdb.org/Documentation/SQLreference/Programming/Python)
 is [monetdb](https://www.monetdb.org) Python client
-* [pymongo](http://api.mongodb.org/python/current/#) allows for work with [MongoDB](http://www.mongodb.com) database
+* [pymongo](https://pymongo.readthedocs.io) and [motor](https://motor.readthedocs.io) allow for work with [MongoDB](http://www.mongodb.com) database
 * [py-leveldb](https://code.google.com/p/py-leveldb/) are thread-safe Python bindings for [LevelDb](https://github.com/google/leveldb)
 
 ### Parallelisation

--- a/best_practices/testing.md
+++ b/best_practices/testing.md
@@ -86,7 +86,7 @@ Once the web page has any interface, e2e tests should be implemented.
 
 ## Dependencies tracking
 
-[David](https://david-dm.org/) or other service depending on codebase language.
+[Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) or other service depending on codebase language.
 
 Checking for dependency updates should be done regularly. It can save a lot of time,
 avoiding code dependent on deprecated functionality.

--- a/citable_software/conferences_journals_workshops.md
+++ b/citable_software/conferences_journals_workshops.md
@@ -6,7 +6,7 @@ This is a list of Conferences, Journals, and Workshops related to eScience.
 
 * [The IEEE International Conference on eScience](https://escience-conference.org/) Yearly (computer science) conference on eScience.
 
-* [UK Conference of Research Software Engineers](https://rse.ac.uk/conf2019/).
+* [UK Conference of Research Software Engineers](https://rsecon2022.society-rse.org/).
 
 * [German Conference of Research Software Engineers](https://www.de-rse.org/en/conf2019/index.html).
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,6 @@
+# Lychee configuration file
+# See https://github.com/lycheeverse/lychee/blob/master/lychee.example.toml
+exclude_all_private = true
+exclude_mail = true
+progress = false
+verbose = true

--- a/nlesc_specific/checklist/checklist_mature.md
+++ b/nlesc_specific/checklist/checklist_mature.md
@@ -53,7 +53,7 @@ build tests|
 [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration), using a [publicly available service](../../best_practices/testing.md#Online-services-for-continuous-integration)
 continuous code coverage and code quality metrics public, minimum 70% coverage required|
 end2end test for (web) user interfaces|
-track dependencies (with [David](https://david-dm.org/) or other service depending on codebase language)|
+track dependencies (with [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) or other service depending on codebase language)|
 
 ## Documentation
 

--- a/nlesc_specific/checklist_matrix.md
+++ b/nlesc_specific/checklist_matrix.md
@@ -74,7 +74,7 @@ build tests||X|
 [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration), using a [publicly available service](../best_practices/testing.md#Online-services-for-continuous-integration)||X|
 continuous code coverage and code quality metrics public, minimum 70% coverage required|||X
 end2end test for (web) user interfaces|||X
-track dependencies (with [David](https://david-dm.org/) or other service depending on codebase language)|||X
+track dependencies (with [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates)) or other service depending on codebase language)|||X
 
 ## Documentation
 

--- a/nlesc_specific/e-infrastructure/das5.md
+++ b/nlesc_specific/e-infrastructure/das5.md
@@ -1,12 +1,15 @@
 # DAS-5
 
+*This text is about DAS-5. However, most of the advice should also be
+applicable to its successor [DAS-6](https://www.cs.vu.nl/das/home.shtml).*
+
 This text gives a couple of practical hints to get you started using the
 DAS-5 quickly. It is intended for people with little to no experience
 using compute clusters.
 
 First of all, and this is the most important point in this text: read
 the usage policy and make sure you understand every word of it:
-http://www.cs.vu.nl/das5/usage.shtml
+https://www.cs.vu.nl/das5/usage.shtml
 
 The DAS-5 consists of multiple cluster sites, the largest one is located
 at the VU, which you can reach using by the hostname

--- a/nlesc_specific/e-infrastructure/e-infrastructure.md
+++ b/nlesc_specific/e-infrastructure/e-infrastructure.md
@@ -12,14 +12,6 @@ Lack of e-Infrastructure should never be a reason for not being able to to a pro
 
 SURF is the most obvious supplier of e-Infrastructure for Netherlands eScience Center projects. For all e-Infrastructure needs we usually first look to SURF. This does not mean SURF is our exclusive e-Infrastructure provider. We use whatever infrastructure is best for the project, provided by SURF or otherwise.
 
-<!--
-### New project meeting with SURF
-
-It is not always apparent what is available at SURF, under what conditions machines can be used, etc. Also SURF is more than willing to try to accommodate any special requests from projects, _if_ some lead-time is available before the infrastructure is actually needed.
-
-Once we have a good idea of what e-Infrastructure is required in a project (probably some time after the official start of a project), a meeting with SURF is held to see what infrastructure needs can be filled with SURF infrastructure. The first point of contact is Jan Bot (jan.bot@surfsara.nl) who works at SURFsara, and across the hall from our office. For now please also invite Niels Drost to the meeting, and perhaps bring your coordinator.
--->
-
 ### Getting access to SURF infrastructure
 
 In general access to SURFsara resources is free of charge for scientists in The Netherlands. For most infrastructure gaining access is a matter of filling in a simple web-form, which you can do yourself on behalf of the scientists in the project. Exceptions are the Cartesius and Lisa, for which a more involved process is required. For these machines, only the PI of a project can submit (or anyone else with an NWO Iris account).
@@ -28,12 +20,12 @@ The Netherlands eScience Center also has access to the infrastructure provided b
 
 ### Available systems at SURF
 
-Here we list some of the most likely to be used resources at SURF. See the [overview of all SURF services and products](https://www.surf.nl/en/services-and-support/services-provided-by-surf), and [detailed information on the SURFsara infrastructure](https://userinfo.surfsara.nl/systems).
+Here we list some of the most likely to be used resources at SURF. See the [overview of SURF services and products](https://www.surf.nl/en/research-it), and [detailed information on the SURFsara infrastructure](https://userinfo.surfsara.nl/systems).
 
 SURFsara:
 
-- **Cartesius**: The national supercomputer of The Netherlands. It contains a lot of very high performance machines, connected through a fast interconnect (about 41000 cores in total, plus 132 GPUs). It also has a large storage system (7+ Pb). Cartesius is typically designed for large parallel applications that require thousands of cores at once.
-- **Lisa**: National Cluster. Similar machines as the Cartesius, without the interconnect (about 8000 cores in total). Storage also more limited. Lisa is typically designed to run lots of small (1 to 16 core) applications at the same time.
+- **Snellius**: Snellius is the Dutch national supercomputer. Snellius is a general purpose capability system and is designed to be a well balanced system. If you need one or more of: many cores, large symmetric multi-processing nodes, high memory, a fast interconnect, a lot of work space on disk, or a fast I/O subsystem then Snellius is the machine of choice.
+- **Lisa**: National Cluster. Similar machines as the Cartesius (the previous Dutch national supercomputer), without the interconnect (about 8000 cores in total). Storage also more limited. Lisa is typically designed to run lots of small (1 to 16 core) applications at the same time.
 - **Grid**: Same machines again, now with a Grid Middleware. Not recommended for use in eScience Center projects.
 - **HPC Cloud**: On demand computing infrastructure. Nice if you need longer running services, or have a lot of special software requirements.
 - **Hadoop**: Big Data analytics framework.


### PR DESCRIPTION
- Update the link checker, because the currently used checker is deprecated.
- Fix broken links
- Only check all links for the main branch and do so every night
