### PR TITLE
replace nlesc.github.io software list with new RSD

### DIFF
--- a/best_practices/language_guides/python.md
+++ b/best_practices/language_guides/python.md
@@ -301,7 +301,7 @@ Having said that, there are many ways to run Python code in parallel:
 * A much simpler alternative in Python 3 is the [`concurrent.futures`](https://docs.python.org/3/library/concurrent.futures.html) module.
 * [IPython / Jupyter notebooks have built-in parallel and distributed computing capabilities](https://ipython.org/ipython-doc/3/parallel/)
 * Many modules have parallel capabilities or can be compiled to have them.
-* At the eScience Center, we have developed the [Noodles package](http://nlesc.github.io/noodles/) for creating computational workflows and automatically parallelizing it by dispatching independent subtasks to parallel and/or distributed systems.
+* At the eScience Center, we have developed the [Noodles package](https://research-software-directory.org/software/noodles) for creating computational workflows and automatically parallelizing it by dispatching independent subtasks to parallel and/or distributed systems.
 
 ### Web Frameworks
 

--- a/best_practices/version_control.md
+++ b/best_practices/version_control.md
@@ -34,7 +34,7 @@ authentication](https://help.github.com/articles/about-two-factor-authentication
 This SHOULD be enabled for your account
 * Project based GitHub organizations
   * MUST have at least two owners that are Netherlands eScience center employees
-  * MUST be [registered](https://github.com/NLeSC/nlesc.github.io#adding-an-github-organization) at [https://nlesc.github.io/](https://nlesc.github.io/), to keep track of all the project organizations
+  * MUST be registered at the [Research Software Directory](https://research-software-directory.org/projects/), to keep track of all the project organizations
   * Private repositories can be created. **NOTE**: The [Netherlands eScience Center IP policy](https://www.esciencecenter.nl/wp-content/uploads/2020/05/nlesc_ip_policy_2017.pdf) applies to any software we contribute to, so the repository SHOULD become open source at some point. To prevent private repositories from remaining unnecessarily private forever please add a brief statement in the README of your repository, clarifying:
     * Why is this repository private?
     * On which date can this repository be made public?


### PR DESCRIPTION
- [x] I followed the [CONTRIBUTING guidelines](../blob/main/CONTRIBUTING.md).

Replaces a reference to where new projects should be registered in the chapter on version control, and updates a reference to the Noodles package from the old to the new directory in Python#Parallelisation

closes #274 