### PR TITLE
Update link check action

### DIFF
--- a/.github/workflows/link-checker-pr.yml
+++ b/.github/workflows/link-checker-pr.yml
@@ -8,7 +8,7 @@ jobs:
       - id: changed_files
         uses: jitterbit/get-changed-files@v1
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.4.1
+        uses: lycheeverse/lychee-action@v1.7.0
         id: lychee
         env:
           GITHUB_TOKEN: ${{secrets.TOKEN_GITHUB}}        

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.4.1
+        uses: lycheeverse/lychee-action@v1.7.0
         id: lychee
         env:
           GITHUB_TOKEN: ${{secrets.TOKEN_GITHUB}}


### PR DESCRIPTION
Update the link check action because the current version issues a deprecationwarning.

> linkChecker
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/



 
