### PR TITLE
Refer people to The Turing Way

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,17 @@
 # Contributing
 
-This Knowledge Base is primarily written by the eScience Research Engineers at the Netherlands eScience Center. The intended audience is anyone interested in eScience and research software development in general or how this is done at the eScience Center specifically.
+This guide is primarily written by the eScience Research Engineers at the Netherlands eScience Center. The intended audience is anyone interested in eScience and research software development in general or how this is done at the eScience Center specifically.
 
 ## Scope
 
-To make sure the information in this knowledge base stays relevant and  up to date it is intentionally low on technical details. The Knowledge base contains information on the process we use to do projects and develop software.
+Please check if your contribution fits in
+[The Turing Way](https://github.com/the-turing-way/the-turing-way)
+before considering contributing to this guide.
+If it does not fit, please open an [issue](https://github.com/NLeSC/guide/issues)
+to discuss your planned contribution before starting to work on it, to avoid
+disappointment later.
+
+To make sure the information in this guide stays relevant and  up to date it is intentionally low on technical details. The guide contains information on the process we use to do projects and develop software.
 
 ## Workflow for making contributions
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,21 @@
 
 # Guide
 
-This is a guide to projects and software development at the Netherlands eScience Center. It both serves as a source of information for exactly how we work at the eScience Center, and as a basis for discussions and reaching consensus on this topic.
+This is a guide to software development at the Netherlands eScience Center.
+It both serves as a source of information for how we work at the eScience
+Center, and as a basis for discussions and reaching consensus on this topic.
 
 **Read The Turing Way instead**
 
-Most of the generic content of this guide has been moved to
-[The Turing Way](https://the-turing-way.netlify.app/index.html).
-Because The Turing Way is language agnostic, we have not yet been able to find
-an appropriate place for the [language guides](best_practices/language_guides/languages_overview.md),
-so we try to keep those up to date.
-*Most of the other information is outdated, be careful when using it.*
-
-**This Guide is a work in progress**
+If you are looking for an overall picture of best practices, read
+[The Turing Way](https://the-turing-way.netlify.app/index.html) first.
+We joined forces with that guide for most of our generic research software
+engineering advice.
+Because The Turing Way is language agnostic, this guide mostly provides
+addtional specific
+[language guides](best_practices/language_guides/languages_overview.md).
+*Please be aware that most remaining language agnostic content is outdated,
+be careful when using it.*
+We plan on removing that content (#286).
 
 If you would like to contribute to this book see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@
 
 This is a guide to projects and software development at the Netherlands eScience Center. It both serves as a source of information for exactly how we work at the eScience Center, and as a basis for discussions and reaching consensus on this topic.
 
+**Read The Turing Way instead**
+
+Most of the generic content of this guide has been moved to
+[The Turing Way](https://the-turing-way.netlify.app/index.html).
+Because The Turing Way is language agnostic, we have not yet been able to find
+an appropriate place for the [language guides](best_practices/language_guides/languages_overview.md),
+so we try to keep those up to date.
+*Most of the other information is outdated, be careful when using it.*
+
 **This Guide is a work in progress**
 
-Read this book online here: https://guide.esciencecenter.nl
-
 If you would like to contribute to this book see [CONTRIBUTING.md](CONTRIBUTING.md).
-
-To see who is responsible for which part of the guide see [chapter_owners.md](chapter_owners.md).
-
-The guide is best read online, but there is a [PDF document](https://doi.org/10.5281/zenodo.4020564) for offline reading.


### PR DESCRIPTION
Update the main page and contribution guidelines to refer people to The Turing Way. Add a warning that many topics in the guide are outdated.
 
Related to #286 
