### PR TITLE
link-checker: exclude private URLs like localhost

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -1,6 +1,6 @@
 # Lychee configuration file
 # See https://github.com/lycheeverse/lychee/blob/master/lychee.example.toml
 exclude_all_private = true
-exclude_mail = true
-progress = false
-verbose = true
+include_mail = false
+no_progress = true
+verbose = "info"


### PR DESCRIPTION
- [x] I followed the [CONTRIBUTING guidelines](../blob/main/CONTRIBUTING.md).

Below, describe what this Pull Request adds:

One of the links that failed the link-checker are a localhost reference. Links like that should never be checked and lychee has an option for that. This PR adds that option.