### PR TITLE
update PR link checker workflow

### DIFF
--- a/.github/workflows/link-checker-pr.yml
+++ b/.github/workflows/link-checker-pr.yml
@@ -1,28 +1,37 @@
 name: Link Checker for Pull requests
 on: pull_request
 jobs:
+  changedFiles:
+    runs-on: ubuntu-latest
+    outputs:
+      files: ${{ steps.changed-markdown-files.outputs.all_changed_files }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get changed markdown files
+        id: changed-markdown-files
+        uses: tj-actions/changed-files@v45
+        with:
+          # Avoid using single or double quotes for multiline patterns
+          files: |
+             **.md
+          matrix: true
+  
   linkChecker:
     runs-on: ubuntu-latest
+    needs: changedFiles
+    strategy:
+      matrix:
+        file: ${{ fromJSON(needs.changedFiles.outputs.files) }}
+      fail-fast: false
     steps:
-      - uses: actions/checkout@v3
-      - id: changed_files
-        uses: jitterbit/get-changed-files@v1
-      - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.7.0
-        id: lychee
-        env:
-          GITHUB_TOKEN: ${{secrets.TOKEN_GITHUB}}        
+      - uses: actions/checkout@v4
         with:
-          args: ${{ steps.changed_files.outputs.all }}
-      - name: Count broken links
+          fetch-depth: 2
+      - name: download Lychee
         run: |
-            broken_max=10
-            broken_count=$(printf "%d" $(grep "🚫 Errors" lychee/out.md | cut -d'|' -f3))
-            if [ "$broken_count" -gt "$broken_max" ]; then
-                echo "Number of broken links (${broken_count}) exceeds maximum allowed number (${broken_max})."
-                cat lychee/out.md
-                exit 1
-            else
-                echo "Number of broken links (${broken_count}) less than or equal to maximum allowed number (${broken_max})."
-                exit 0
-            fi
+          wget https://github.com/lycheeverse/lychee/releases/download/nightly/lychee-x86_64-unknown-linux-gnu.tar.gz
+          tar xzf lychee-x86_64-unknown-linux-gnu.tar.gz
+      - name: Check all this file's additions for broken links
+        run: |
+          export base_sha=$(git rev-parse ${{ github.sha }}^)
+          git diff -U0 ${base_sha} ${{ github.event.pull_request.head.sha }} -- ${{ matrix.file }} | grep -v "+++" | grep "^+" | cut -c 2- | ./lychee -

--- a/.github/workflows/link-checker-pr.yml
+++ b/.github/workflows/link-checker-pr.yml
@@ -19,6 +19,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     needs: changedFiles
+    if: ${{ needs.changedFiles.outputs.files != '' && toJSON(fromJSON(needs.changedFiles.outputs.files)) != '[]' }}
     strategy:
       matrix:
         file: ${{ fromJSON(needs.changedFiles.outputs.files) }}


### PR DESCRIPTION
Fixes #345.

Use a different changed-files checker (the old one was no longer maintained) and also make the link checking more fine-grained by only checking added lines for broken links.

We now use a matrix to parallelize over changed files. This slows down the complete workflow a bit in some cases, but it does offer a nicer user experience, because the files that are checked will now be shown in the GitHub UI itself, instead of only in the workflow run logs.

Lychee is installed directly from the GitHub nightly release. This is really fast. The original reason, though, was because there is no Ubuntu package for Lychee. Works out well, though.

Determining the base SHA is a bit convoluted, because GitHub does not provide this in a usable way. See
https://www.kenmuse.com/blog/the-many-shas-of-a-github-pull-request/ for a good overview of this problem. The git rev-parse command was suggested there. The fetch depth must be at least two, otherwise the base SHA cannot be used.
