### PR TITLE
342 turing way url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ The guide contains and links to best practices we use to code and develop resear
 The main goal: having information available about research software engineering best practices for our colleagues, collaborators and other interested people.
 It can be information that you can give a colleague starting in some area, for instance, a new language or a new technology.
 
-80% of this goal will be met by [the Turing Way](https://the-turing-way.netlify.app/).
+80% of this goal will be met by [the Turing Way](https://book.the-turing-way.org/).
 For everything else: we have the Guide.
 
 We focus on eScience Center-specific best practices.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Center, and as a basis for discussions and reaching consensus on this topic.
 **Read The Turing Way instead**
 
 If you are looking for an overall picture of best practices, read
-[The Turing Way](https://the-turing-way.netlify.app/index.html) first.
+[The Turing Way](https://book.the-turing-way.org/index.html) first.
 We joined forces with that guide for most of our generic research software
 engineering advice.
 Because The Turing Way is programming language agnostic, this guide provides

--- a/best_practices/code_quality.md
+++ b/best_practices/code_quality.md
@@ -1,8 +1,8 @@
 # Code Quality
 
-Ways to improve code quality are in the [Code quality](https://the-turing-way.netlify.app/reproducible-research/code-quality.html) chapter on the Turing Way.
+Ways to improve code quality are in the [Code quality](https://book.the-turing-way.org//reproducible-research/code-quality.html) chapter on the Turing Way.
 
-There are [online software quality improvement tools](https://the-turing-way.netlify.app/reproducible-research/code-quality/code-quality-style.html#online-services-providing-software-quality-checks) see the [language guides](language_guides/languages_overview.md) for good options per language.
+There are [online software quality improvement tools](https://book.the-turing-way.org/reproducible-research/code-quality/code-quality-style.html#online-services-providing-software-quality-checks) see the [language guides](language_guides/languages_overview.md) for good options per language.
 
 ## Editorconfig
 

--- a/best_practices/code_quality.md
+++ b/best_practices/code_quality.md
@@ -2,7 +2,7 @@
 
 Ways to improve code quality are in the [Code quality](https://book.the-turing-way.org//reproducible-research/code-quality.html) chapter on the Turing Way.
 
-There are [online software quality improvement tools](https://book.the-turing-way.org/reproducible-research/code-quality/code-quality-style.html#online-services-providing-software-quality-checks) see the [language guides](language_guides/languages_overview.md) for good options per language.
+There are [online software quality improvement tools](https://book.the-turing-way.org/reproducible-research/code-quality/code-quality-style.html#online-services-providing-software-quality-checks) see the [language guides](/language_guides/languages_overview.md) for good options per language.
 
 ## Editorconfig
 

--- a/best_practices/documentation.md
+++ b/best_practices/documentation.md
@@ -87,8 +87,8 @@ developer and contributor since things have to be explained only once. A good CO
 file describes at least how to perform the following tasks:
 
 * How to [install the dependencies](#documented-development-setup)
-* How to run [(unit) tests](https://the-turing-way.netlify.app/reproducible-research/testing/testing-unittest)
-* What [code style](https://the-turing-way.netlify.app/reproducible-research/code-quality/code-quality-style.html) to use
+* How to run [(unit) tests](https://book.the-turing-way.org/reproducible-research/testing/testing-unittest)
+* What [code style](https://book.the-turing-way.org/reproducible-research/code-quality/code-quality-style.html) to use
 * Reference to [code of conduct](#code-of-conduct)
 * Mention the [git branching model](https://www.atlassian.com/git/tutorials/comparing-workflows) when using anything else than the [GitHub flow branching model](https://guides.github.com/introduction/flow/)
 

--- a/best_practices/overview.md
+++ b/best_practices/overview.md
@@ -10,7 +10,7 @@ things done faster.
 
 ### Learn how to use the command line efficiently
 
-Read the chapter on using [Bash](language_guides/bash.md).
+Read the chapter on using [Bash](/language_guides/bash.md).
 
 ### Use an editor that helps you develop
 

--- a/language_guides/python.md
+++ b/language_guides/python.md
@@ -189,7 +189,7 @@ The development environment will typically accumulate (old) packages during deve
 ### Code coverage
 
 When you have tests it is also a good to see which source code is exercised by the test suite.
-[Code coverage](https://the-turing-way.netlify.app/reproducible-research/testing/testing-guidance#aim-to-have-a-good-code-coverage) can be measured with the [coverage](https://coverage.readthedocs.io) Python package.
+[Code coverage](https://book.the-turing-way.org/reproducible-research/testing/testing-guidance#aim-to-have-a-good-code-coverage) can be measured with the [coverage](https://coverage.readthedocs.io) Python package.
 The coverage package can also generate html reports which show which line was covered.
 Most test runners have have the coverage package integrated.
 
@@ -199,9 +199,9 @@ If this is not possible or does not fit then use a generic code coverage service
 
 ## Code quality analysis tools and services
 
-Code quality service is explained in the [The Turing Way](https://the-turing-way.netlify.app/reproducible-research/code-quality/code-quality-style.html#online-services-providing-software-quality-checks).
+Code quality service is explained in the [The Turing Way](https://book.the-turing-way.org/reproducible-research/code-quality/code-quality-style.html#online-services-providing-software-quality-checks).
 There are multiple code quality services available for Python, all of which have their pros and cons.
-See [The Turing Way](https://the-turing-way.netlify.app/reproducible-research/code-quality/code-quality-resources.html) for links to lists of possible services.
+See [The Turing Way](https://book.the-turing-way.org/reproducible-research/code-quality/code-quality-resources.html) for links to lists of possible services.
 We currently setup [Sonarcloud](https://sonarcloud.io/) by default in our [Python template](https://github.com/NLeSC/python-template).
 To reproduce the Sonarcloud pipeline locally, you can use [SonarLint](https://www.sonarlint.org/) in your IDE.
 If you use another editor, perhaps it is more convenient to pick another service like Codacy or Codecov.

--- a/language_guides/r.md
+++ b/language_guides/r.md
@@ -127,7 +127,7 @@ R function documentation offers plenty of space to document the functionality, i
 See also [checking](http://r-pkgs.had.co.nz/check.html) and [testing](http://r-pkgs.had.co.nz/tests.html) R packages. note that within RStudio R package check and R package test can be done via simple toolbar clicks.
 
 ### Continuous integration
-[Continuous integration](https://the-turing-way.netlify.app/reproducible-research/ci) should be done with an online service.
+[Continuous integration](https://book.the-turing-way.org/reproducible-research/ci) should be done with an online service.
 
 ### Debugging and Profiling
 Debugging is possible in RStudio, see [link](https://support.posit.co/hc/en-us/articles/205612627-Debugging-with-RStudio). For profiling tips see [link](http://adv-r.had.co.nz/Profiling.html)


### PR DESCRIPTION
* Replace the old links to The Turing Way (`https://the-turing-way.netlify.app`) with the new URL (`https://book.the-turing-way.org`)
* Fix two broken links to the language guides (which were broken by the move of the language guide in #340)

Closes #342
