### PR TITLE
[CI] update link checker and handle status 429 (too many requests)

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -11,9 +11,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.7.0
+        uses: lycheeverse/lychee-action@v2
         id: lychee
+        with:
+          # note: args has a long default value; when you override it, make sure you don't accidentally forget to include the default options you want! see https://github.com/lycheeverse/lychee-action/blob/master/action.yml
+          args: --verbose --no-progress './**/*.md' './**/*.html' './**/*.rst' --accept '100..=103,200..=299, 429'
         env:
+          # This token is included to avoid github.com requests to error out with status 429 (too many requests). It only works for GitHub requests (also other GitHub REST API calls), not for the rest of the web.
           GITHUB_TOKEN: ${{secrets.TOKEN_GITHUB}}
       - name: Count broken links
         run: |

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -9,7 +9,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.7.0
         id: lychee

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -20,15 +20,3 @@ jobs:
         env:
           # This token is included to avoid github.com requests to error out with status 429 (too many requests). It only works for GitHub requests (also other GitHub REST API calls), not for the rest of the web.
           GITHUB_TOKEN: ${{secrets.TOKEN_GITHUB}}
-      - name: Count broken links
-        run: |
-            broken_max=10
-            broken_count=$(printf "%d" $(grep "🚫 Errors" lychee/out.md | cut -d'|' -f3))
-            if [ "$broken_count" -gt "$broken_max" ]; then
-                echo "Number of broken links (${broken_count}) exceeds maximum allowed number (${broken_max})."
-                cat lychee/out.md
-                exit 1
-            else
-                echo "Number of broken links (${broken_count}) less than or equal to maximum allowed number (${broken_max})."
-                exit 0
-            fi

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,5 +1,6 @@
 name: Link Checker
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/best_practices/releases.md
+++ b/best_practices/releases.md
@@ -63,7 +63,7 @@ some of the things in this *scan* could be automated with continuous integration
 
 ### Citeable
 
-Create a DOI for each release see [Making software citable](../citable_software/making_software_citable.md).
+Create a DOI for each release see [Making software citable](https://book.the-turing-way.org/communication/citable/citable-cff.html?highlight=citable).
 
 ### Dissemination
 

--- a/language_guides/ccpp.md
+++ b/language_guides/ccpp.md
@@ -287,7 +287,7 @@ This all makes xtensor a very interesting choice compared to similar older libra
 
 
 ### Parallel processing
-* [Intel TBB](https://www.threadingbuildingblocks.org) (Threading Building Blocks): template library for task parallelism
+* [oneAPI Threading Building Blocks](https://oneapi-src.github.io/oneTBB/) (oneTBB): template library for task parallelism
 * [ZeroMQ](http://zeromq.org): lower level flexible communication library with a unified interface for message passing between threads and processes, but also between separate machines via TCP.
 
 

--- a/language_guides/python.md
+++ b/language_guides/python.md
@@ -321,7 +321,7 @@ Having said that, there are many ways to run Python code in parallel:
 There are convenient Python web frameworks available:
 
 * [flask](http://flask.pocoo.org/)
-* [cherrypy](http://www.cherrypy.org/)
+* [CherryPy](https://cherrypy.dev/)
 * [Django](https://www.djangoproject.com/)
 * [bottle](http://bottlepy.org/) (similar to flask, but a bit more light-weight for a JSON-REST service)
 


### PR DESCRIPTION
This PR:

- Updates checkout action to version 4
- Updates the lychee action to version 2
- Makes lychee accept status 429 (too many requests) as a successful check. This makes some sense: a 429 may very well be a live link, just one that currently you are not allowed to view. If it were a broken link, the server should return 404 instead. I'm not 100% sure if all webservers work this way (i.e. if they first check for 404 and only then apply throttling to give 429), but in any case it seems the best we can do, because we cannot otherwise control request rate from GitHub Actions, as far as I know.
- Adds a manual run trigger to the link checker
- Removes the workflow part where we only fail if there are 10 or more broken links. I think we can get to 0 broken links by using lychee options, like indeed the one above for 429 and handling other broken links properly as well or excluding them explicitly. I think this is preferable to leaving up to 9 broken links for possibly a long time.