### PR TITLE
Track page views

### DIFF
--- a/.github/workflows/link-checker-pr.yml
+++ b/.github/workflows/link-checker-pr.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 2
       - name: download Lychee
         run: |
-          wget https://github.com/lycheeverse/lychee/releases/download/nightly/lychee-x86_64-unknown-linux-gnu.tar.gz
+          wget https://github.com/lycheeverse/lychee/releases/download/lychee-v0.18.1/lychee-x86_64-unknown-linux-gnu.tar.gz
           tar xzf lychee-x86_64-unknown-linux-gnu.tar.gz
       - name: Check all this file's additions for broken links
         run: |

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
       };
     </script>
     <script src="https://cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/docsify/lib/plugins/external-script.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs/components/prism-bash.min.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -56,12 +56,8 @@
         relativePath: true,
       };
     </script>
-    <script
-      src="https://cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"
-      data-ga="UA-55088238-8"
-    ></script>
+    <script src="https://cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/docsify/lib/plugins/ga.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs/components/prism-bash.min.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -33,6 +33,11 @@
         g.src = u + "matomo.js";
         s.parentNode.insertBefore(g, s);
       })();
+      window.addEventListener("hashchange", function () {
+        _paq.push(["setCustomUrl", "/" + window.location.hash]);
+        _paq.push(["setDocumentTitle", document.title]);
+        _paq.push(["trackPageView"]);
+      });
     </script>
     <!-- End Matomo Code -->
   </head>

--- a/privacy.md
+++ b/privacy.md
@@ -3,7 +3,6 @@
 We collect anonymised user data that helps us to monitor the effectiveness of our website.
 No personally identifiable information is recorded and no cookies containing such information are set in your browser session.
 
-<!-- The commented out section below doesn't seem to work in Docsify... -->
-<!-- ## Analytics opt-out
+<!-- ## Analytics opt-out -->
 <div id="matomo-opt-out"></div>
-<script src="https://matomo.research.software/index.php?module=CoreAdminHome&action=optOutJS&divId=matomo-opt-out&language=auto&showIntro=1"></script> -->
+<script src="https://matomo.research.software/index.php?module=CoreAdminHome&action=optOutJS&divId=matomo-opt-out&language=auto&showIntro=1"></script>


### PR DESCRIPTION
# Changes in this PR

Fixes #421

Adds track navigation changes to matomo and
adds the opting out from matomo tracking on privacy page.
It also drops the remnant of Google Analytics.

# Checklist
<!--
Use the checklist below to make sure you followed the [CONTRIBUTING guidelines](https://guide.esciencecenter.nl/#/CONTRIBUTING).
Feel free to remove what is not applicable.
-->

## SIGNIFICANT changes / additions, e.g. new chapters
- [x] I checked whether the contribution fits in [The Turing Way](https://github.com/the-turing-way/the-turing-way) before considering contributing to this Guide.
- [x] I discussed my contribution in an issue and took into account feedback.

## ALL contributions
- [x] I previewed my changes locally using e.g. `python3 -m http.server 4000` and confirmed they work correctly.
- [x] I checked for broken links, e.g. using the link checker GitHub Action workflow, or locally by using ``docker run --init -it -v `pwd`:/docs lycheeverse/lychee /docs --config=docs/lychee.toml``, at least for the files I changed.
- [x] My name was added to the `CITATION.cff` file.
