### PR TITLE
use the matomo plugin, but customized

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
           return;
         }
 
-        hook.beforeEach(collect);
+        hook.ready(collect);
       };
 
       window.$docsify = window.$docsify || {};

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="/styles.css" />
     <link rel="icon" type="image/png" href="images/favicon.png" />
     <!-- Matomo -->
-    <script>
+    <!-- <script>
       var _paq = (window._paq = window._paq || []);
       _paq.push(["disableCookies"]); // Call disableCookies before calling trackPageView
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -38,7 +38,7 @@
         _paq.push(["setDocumentTitle", document.title]);
         _paq.push(["trackPageView"]);
       });
-    </script>
+    </script> -->
     <!-- End Matomo Code -->
   </head>
 
@@ -54,11 +54,59 @@
           "/.*/_sidebar.md": "/_sidebar.md",
         },
         relativePath: true,
+        matomo: {
+          host: '//matomo.research.software',
+          id: 5
+        },
       };
     </script>
     <script src="https://cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/docsify/lib/plugins/external-script.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs/components/prism-bash.min.js"></script>
+     <!-- custom version of Matomo plugin, modified from https://github.com/docsifyjs/docsify/blob/develop/src/plugins/matomo.js -->
+    <script>
+      function appendScript(options) {
+        const script = document.createElement('script');
+        script.async = true;
+        script.src = options.host + '/matomo.js';
+        document.body.appendChild(script);
+      }
+
+      function init(options) {
+        window._paq = window._paq || [];
+        window._paq.push(["disableCookies"]); // Call disableCookies before calling trackPageView
+        window._paq.push(['trackPageView']);
+        window._paq.push(['enableLinkTracking']);
+        setTimeout(() => {
+          appendScript(options);
+          window._paq.push(['setTrackerUrl', options.host + '/matomo.php']);
+          window._paq.push(['setSiteId', String(options.id)]);
+        }, 0);
+      }
+
+      function collect() {
+        if (!window._paq) {
+          init($docsify.matomo);
+        }
+
+        window._paq.push(['setCustomUrl', window.location.hash.substr(1)]);
+        window._paq.push(['setDocumentTitle', document.title]);
+        window._paq.push(['trackPageView']);
+      }
+
+      const install = function (hook) {
+        if (!$docsify.matomo) {
+          // eslint-disable-next-line no-console
+          console.error('[Docsify] matomo is required.');
+          return;
+        }
+
+        hook.beforeEach(collect);
+      };
+
+      window.$docsify = window.$docsify || {};
+      $docsify.plugins = [install, ...($docsify.plugins || [])];
+    </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
           init($docsify.matomo);
         }
 
-        window._paq.push(["setCustomUrl", "/" +  window.location.hash]);
+        window._paq.push(["setCustomUrl", "/" + window.location.hash]);
         window._paq.push(["setDocumentTitle", document.title]);
         window._paq.push(["trackPageView"]);
       }

--- a/index.html
+++ b/index.html
@@ -55,8 +55,8 @@
         },
         relativePath: true,
         matomo: {
-          host: '//matomo.research.software',
-          id: 5
+          host: "//matomo.research.software",
+          id: 5,
         },
       };
     </script>
@@ -64,24 +64,24 @@
     <script src="https://cdn.jsdelivr.net/npm/docsify/lib/plugins/external-script.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs/components/prism-bash.min.js"></script>
-     <!-- custom version of Matomo plugin, modified from https://github.com/docsifyjs/docsify/blob/develop/src/plugins/matomo.js -->
+    <!-- custom version of Matomo plugin, modified from https://github.com/docsifyjs/docsify/blob/develop/src/plugins/matomo.js -->
     <script>
       function appendScript(options) {
-        const script = document.createElement('script');
+        const script = document.createElement("script");
         script.async = true;
-        script.src = options.host + '/matomo.js';
+        script.src = options.host + "/matomo.js";
         document.body.appendChild(script);
       }
 
       function init(options) {
         window._paq = window._paq || [];
         window._paq.push(["disableCookies"]); // Call disableCookies before calling trackPageView
-        window._paq.push(['trackPageView']);
-        window._paq.push(['enableLinkTracking']);
+        window._paq.push(["trackPageView"]);
+        window._paq.push(["enableLinkTracking"]);
         setTimeout(() => {
           appendScript(options);
-          window._paq.push(['setTrackerUrl', options.host + '/matomo.php']);
-          window._paq.push(['setSiteId', String(options.id)]);
+          window._paq.push(["setTrackerUrl", options.host + "/matomo.php"]);
+          window._paq.push(["setSiteId", String(options.id)]);
         }, 0);
       }
 
@@ -90,15 +90,15 @@
           init($docsify.matomo);
         }
 
-        window._paq.push(['setCustomUrl', window.location.hash.substr(1)]);
-        window._paq.push(['setDocumentTitle', document.title]);
-        window._paq.push(['trackPageView']);
+        window._paq.push(["setCustomUrl", window.location.hash.substr(1)]);
+        window._paq.push(["setDocumentTitle", document.title]);
+        window._paq.push(["trackPageView"]);
       }
 
       const install = function (hook) {
         if (!$docsify.matomo) {
           // eslint-disable-next-line no-console
-          console.error('[Docsify] matomo is required.');
+          console.error("[Docsify] matomo is required.");
           return;
         }
 

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
           init($docsify.matomo);
         }
 
-        window._paq.push(["setCustomUrl", window.location.hash.substr(1)]);
+        window._paq.push(["setCustomUrl", "/" +  window.location.hash]);
         window._paq.push(["setDocumentTitle", document.title]);
         window._paq.push(["trackPageView"]);
       }

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
         matomo: {
           host: "//matomo.research.software",
           id: 5,
+          disableCookies: true,
         },
       };
     </script>
@@ -75,7 +76,9 @@
 
       function init(options) {
         window._paq = window._paq || [];
-        window._paq.push(["disableCookies"]); // Call disableCookies before calling trackPageView
+        if (options.disableCookies) {
+          window._paq.push(["disableCookies"]); // Call disableCookies before calling trackPageView
+        }
         window._paq.push(["trackPageView"]);
         window._paq.push(["enableLinkTracking"]);
         setTimeout(() => {

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
           init($docsify.matomo);
         }
 
-        window._paq.push(["setCustomUrl", window.location.hash]);
+        window._paq.push(["setCustomUrl", window.location.hash.substr(1)]);
         window._paq.push(["setDocumentTitle", document.title]);
         window._paq.push(["trackPageView"]);
       }

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
           init($docsify.matomo);
         }
 
-        window._paq.push(["setCustomUrl", window.location.hash.substr(1)]);
+        window._paq.push(["setCustomUrl", window.location.hash]);
         window._paq.push(["setDocumentTitle", document.title]);
         window._paq.push(["trackPageView"]);
       }

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
         if (options.disableCookies) {
           window._paq.push(["disableCookies"]); // Call disableCookies before calling trackPageView
         }
-        window._paq.push(["trackPageView"]);
+        // window._paq.push(["trackPageView"]);
         window._paq.push(["enableLinkTracking"]);
         setTimeout(() => {
           appendScript(options);

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
           return;
         }
 
-        hook.ready(collect);
+        hook.doneEach(collect);
       };
 
       window.$docsify = window.$docsify || {};


### PR DESCRIPTION
# Changes in this PR

This is another stab at fixing #421 (previous try in #432). This time, we try to use the "official" (though undocumented) Matomo plugin, copy-pasted here because we need an adaptation: the disableCookies option. Also, we need to check whether this works at all, because the official plugin is pretty old (5 years) and also it seems to have the same problem as our previous implementation (see https://github.com/NLeSC/guide/issues/421#issuecomment-2782462053), i.e. it uses `hook.beforeEach`.

# Checklist
<!--
Use the checklist below to make sure you followed the [CONTRIBUTING guidelines](https://guide.esciencecenter.nl/#/CONTRIBUTING).
Feel free to remove what is not applicable.
-->

## SIGNIFICANT changes / additions, e.g. new chapters
- [x] I checked whether the contribution fits in [The Turing Way](https://github.com/the-turing-way/the-turing-way) before considering contributing to this Guide.
- [x] I discussed my contribution in an issue and took into account feedback.

## ALL contributions
- [x] I previewed my changes locally using e.g. `python3 -m http.server 4000` and confirmed they work correctly.
- [x] I checked for broken links, e.g. using the link checker GitHub Action workflow, or locally by using ``docker run --init -it -v `pwd`:/docs lycheeverse/lychee /docs --config=docs/lychee.toml``, at least for the files I changed.
- [x] My name was added to the `CITATION.cff` file.
