### PR TITLE
Fix the error that prevented generating the PDF guide on release

### DIFF
--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm install @iomeg/zenodo-upload
 
       - name: Pull Docker image
-        run: docker pull ghcr.io/kernoeb/docker-docsify-pdf:latest
+        run: docker pull ghcr.io/kernoeb/docker-docsify-pdf:main
 
       - name: Generate PDF using the Docker image
         run: |
@@ -32,7 +32,8 @@ jobs:
             -v "${{ github.workspace }}/images/pdf-cover.pdf":/home/node/resources/cover.pdf:rw \
             --user $(id -u):$(id -g) \
             -e "PDF_OUTPUT_NAME=guide-nlesc.pdf" \
-            ghcr.io/kernoeb/docker-docsify-pdf:latest
+            -e "NO_SANDBOX=true" \
+            ghcr.io/kernoeb/docker-docsify-pdf:main
 
       - name: Upload PDF as an artifact
         if: always()


### PR DESCRIPTION
# Changes in this PR
Updated the Generate PDF GitHub action to use the `--no-sandbox` for chromium, as explained in https://github.com/kernoeb/docker-docsify-pdf/issues/13. 

This should fix https://github.com/NLeSC/guide/issues/270#issuecomment-2778113525.

Note: We are using the `main` tag and not latest, because they did not make a release since they introduced `--no-sandbox`.

I tested the updated GitHub Action [here](https://github.com/NLeSC/guide/actions/runs/14710221587).

# Checklist
<!--
Use the checklist below to make sure you followed the [CONTRIBUTING guidelines](https://guide.esciencecenter.nl/#/CONTRIBUTING).
Feel free to remove what is not applicable.
-->

## SIGNIFICANT changes / additions, e.g. new chapters
- [x] I checked whether the contribution fits in [The Turing Way](https://github.com/the-turing-way/the-turing-way) before considering contributing to this Guide.
- [x] I discussed my contribution in an issue and took into account feedback.
