### PR TITLE
Adding zenodraft action

### DIFF
--- a/.github/workflows/upload-pdf.yml
+++ b/.github/workflows/upload-pdf.yml
@@ -1,0 +1,49 @@
+# Generates a PDF for the full guide and uploads it to Zenodo
+## This action triggers when there is a new release of the guide
+## Manual release of this action also triggers upload to the Zenodo Sandbox
+name: Generate PDF
+on:
+  # Trigger manually via the Actions tab
+  workflow_dispatch:
+  # Trigger when you publish a release via GitHub's release page
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout the contents of your repository
+          uses: actions/checkout@v4
+
+        - name: Change absolute paths to relative
+          run: perl -pi -e 's@\]\(\/@\]\(@' _sidebar.md
+  
+        - name: Pull Docker image
+          run: docker pull ghcr.io/kernoeb/docker-docsify-pdf:main
+
+        - name: Generate PDF using the Docker image
+          run: |
+            docker run --rm --privileged \
+              -v "${{ github.workspace }}/":/home/node/docs:rw \
+              -v "${{ github.workspace }}/":/home/node/pdf:rw \
+              -v "${{ github.workspace }}/images/pdf-cover.pdf":/home/node/resources/cover.pdf:rw \
+              --user $(id -u):$(id -g) \
+              -e "PDF_OUTPUT_NAME=guide-nlesc.pdf" \
+              -e "NO_SANDBOX=true" \
+              ghcr.io/kernoeb/docker-docsify-pdf:main
+           
+        - name: Create a draft snapshot of your repository contents as a new
+                version in concept 14965744 on Zenodo Sandbox using metadata
+                from repository file .zenodo.json
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            ZENODO_SANDBOX_ACCESS_TOKEN: ${{ secrets.ZENODO_SANDBOX_ACCESS_TOKEN }}
+          uses: zenodraft/action@0.13.3
+          with:
+            concept: 14965744
+            metadata: .zenodo.json
+            publish: false
+            sandbox: true
+            filenames: guide-nlesc.pdf

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,215 @@
+{
+  "creators": [
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Drost, Niels",
+      "orcid": "0000-0001-9795-7981"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Spaaks, Jurriaan H.",
+      "orcid": "0000-0002-7064-4069"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Andela, Bouwe"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Veen, Lourens"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "van der Zwaan, Janneke M.",
+      "orcid": "0000-0002-8329-7000"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Verhoeven, Stefan",
+      "orcid": "0000-0002-5821-2060"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Bos, Patrick"
+    },
+    {
+      "name": "Kuzak, Mateusz",
+      "orcid": "0000-0003-0087-6021"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "van Werkhoven, Ben",
+      "orcid": "0000-0002-7508-3272"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Attema, Jisk",
+      "orcid": "0000-0002-0948-1176"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Hidding, Johannes"
+    },
+    {
+      "name": "van Hees, Vincent",
+      "orcid": "0000-0003-0182-9008"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Martinez-Ortiz, Carlos",
+      "orcid": "0000-0001-5565-7577"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Spreeuw, Hanno",
+      "orcid": "0000-0002-5057-0322"
+    },
+    {
+      "name": "Borgdorff, Joris",
+      "orcid": "0000-0001-7911-9490"
+    },
+    {
+      "name": "Leinweber, Katrin"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Diblen, Faruk"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "van den Oord, Gijs"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Goncalves, Romulo",
+      "orcid": "0000-0003-2225-1428"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Kuzniar, Arnold",
+      "orcid": "0000-0003-1711-7961"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "van Kuppevelt, Dafne"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Weel, Berend"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Meijer, Christiaan"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Maassen, Jason",
+      "orcid": "0000-0002-8172-4865"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Rodríguez-Sánchez, Pablo",
+      "orcid": "0000-0002-2855-940X"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Klaver, Tom"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "van Hage, Willem Robert",
+      "orcid": "0000-0002-6478-3003"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Zapata, Felipe",
+      "orcid": "0000-0001-8286-677X"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Bakker, Tom"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "van Rijn, Sander",
+      "orcid": "0000-0001-6159-041X"
+    },
+    {
+      "affiliation": "Journal of Open Source Software",
+      "name": "Niemeyer, Kyle"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Wehner, Jens"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "van der Burg, Sven"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Siqueira, Abel"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Vreede, Barbara"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Schnober, Carsten"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Chandramouli, Pranav"
+    },
+    {
+      "affiliation": "Utrecht University",
+      "name": "Oberman, Hanne"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Lüken, Malte"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Isazi, Alessio"
+    },
+    {
+      "affiliation": "Datadog, Inc.",
+      "name": "Lev, Ofek"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Cahen, Ewan"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Ali, Suvayu"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Hafner, Flavio"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Cushing, Reggie"
+    },
+    {
+      "affiliation": "Netherlands eScience Center",
+      "name": "Kasalica, Vedran",
+      "orcid": "0000-0002-0097-1056"
+    },
+    {
+      "affiliation": "Utrecht University",
+      "name": "Vargas Honorato, Rodrigo",
+      "orcid": "0000-0001-5267-3002"
+    }
+  ],
+  "description": "This is a guide to software development and projects at the Netherlands eScience Center. It both serves as a source of information for exactly how we work at the eScience Center, and as a basis for discussions and reaching consensus on this topic.",
+  "license": {
+    "id": "CC-BY-4.0"
+  },
+  "publication_date": "2019-08-07",
+  "title": "Software Development Guide",
+  "version": "2019-08-07"
+}


### PR DESCRIPTION
# Changes in this PR
Adds GitHub action for publishing Guide as PDF in Zenodo using [Zenodraft](https://github.com/marketplace/actions/zenodraft) workflow.
#270 

One thing I am not sure is how to configure the action so that it can be manually tested on Zenodo Sandbox, and publishes to Zenodo on releases. The action would require two separate concept DOIs, but it looks like only one can be given. Any suggestions?

# Checklist
Most check items are not relevant for this PR since it does not modify the content of the guide, but the publishing infrastructure.
## SIGNIFICANT changes / additions, e.g. new chapters
- [ ] I checked whether the contribution fits in [The Turing Way](https://github.com/the-turing-way/the-turing-way) before considering contributing to this Guide.
- [ ] I discussed my contribution in an issue and took into account feedback.

## ALL contributions
- [ ] I previewed my changes locally using e.g. `python3 -m http.server 4000` and confirmed they work correctly.
- [ ] I checked for broken links, e.g. using the link checker GitHub Action workflow, or locally by using ``docker run --init -it -v `pwd`:/docs lycheeverse/lychee /docs --config=docs/lychee.toml``, at least for the files I changed.
- [ ] My name was added to the `CITATION.cff` file.
